### PR TITLE
Add fileDiffDao getSyncPath method for rule

### DIFF
--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -882,6 +882,10 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
     }
   }
 
+  public List<String> getSyncPath(int size) throws MetaStoreException {
+    return fileDiffDao.getSyncPath(size);
+  }
+
   @Override
   public List<FileDiff> getPendingDiff() throws MetaStoreException {
     return fileDiffDao.getPendingDiff();

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileDiffDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileDiffDao.java
@@ -75,6 +75,18 @@ public class FileDiffDao {
         new FileDiffRowMapper());
   }
 
+  public List<String> getSyncPath(int size) {
+    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+    if (size != 0) {
+      jdbcTemplate.setMaxRows(size);
+    }
+    String sql = "select DISTINCT src from " + TABLE_NAME +
+        " where state=?";
+    return jdbcTemplate
+        .queryForList(sql, String.class, FileDiffState.RUNNING.getValue());
+  }
+
+
   public FileDiff getById(long did) {
     JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
     return jdbcTemplate.queryForObject("select * from " + TABLE_NAME + " where did = ?",

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileDiffDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileDiffDao.java
@@ -66,7 +66,7 @@ public class TestFileDiffDao extends TestDaoUtil {
     fileDiffs[0].setDiffId(1);
     fileDiffs[0].setParameters(new HashMap<String, String>());
     fileDiffs[0].setSrc("test");
-    fileDiffs[0].setState(FileDiffState.PENDING);
+    fileDiffs[0].setState(FileDiffState.RUNNING);
     fileDiffs[0].setDiffType(FileDiffType.APPEND);
     fileDiffs[0].setCreate_time(1);
 
@@ -83,6 +83,8 @@ public class TestFileDiffDao extends TestDaoUtil {
     for (int i = 0; i < 2; i++) {
       Assert.assertTrue(fileInfoList.get(i).equals(fileDiffs[i]));
     }
+    List<String> paths = fileDiffDao.getSyncPath(0);
+    Assert.assertTrue(paths.size() == 1);
   }
 
   @Test


### PR DESCRIPTION
* Return List<String> paths without duplicate values
* size is used to control number of return values, when size = 0, then return all values.