### PR TITLE
Refine baseSync and failure handling 

### DIFF
--- a/smart-common/src/main/java/org/smartdata/model/FileDiffState.java
+++ b/smart-common/src/main/java/org/smartdata/model/FileDiffState.java
@@ -22,7 +22,8 @@ public enum FileDiffState {
   RUNNING(1), // Still running
   APPLIED(2),
   MERGED(3),
-  DELETED(4);
+  DELETED(4),
+  FAILED(5);
 
   private int value;
 

--- a/smart-common/src/main/java/org/smartdata/model/FileDiffType.java
+++ b/smart-common/src/main/java/org/smartdata/model/FileDiffType.java
@@ -23,7 +23,8 @@ public enum FileDiffType {
   DELETE(1),
   RENAME(2),
   APPEND(3),
-  METADATA(4);
+  METADATA(4),
+  BASESYNC(5);
 
   private int value;
 

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CopyFileAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CopyFileAction.java
@@ -193,9 +193,9 @@ public class CopyFileAction extends HdfsAction {
       return fs.create(new Path(dest), (short) replication);
     } else {
       // Copy between different dirs of the same cluster
-      if (dfsClient.exists(dest)) {
-        // TODO local append
-      }
+      // TODO local append
+      // if (dfsClient.exists(dest)) {
+      // }
       return dfsClient.create(dest, true);
     }
   }

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -183,9 +183,6 @@ public class CopyScheduler extends ActionSchedulerService {
             // Remove from chain top
             fileDiffChainMap.get(fileDiff.getSrc()).removeHead();
           }
-          if (fileLock.containsKey(fileDiff.getSrc())) {
-            fileLock.remove(fileDiff.getSrc());
-          }
           metaStore.updateFileDiff(did, FileDiffState.APPLIED);
           if (fileDiffMap.containsKey(did)) {
             fileDiffMap.remove(did);
@@ -201,6 +198,9 @@ public class CopyScheduler extends ActionSchedulerService {
               fileDiffMap.put(did, curr + 1);
             }
           }
+        }
+        if (fileLock.containsKey(fileDiff.getSrc())) {
+          fileLock.remove(fileDiff.getSrc());
         }
       } catch (MetaStoreException e) {
         LOG.error("Mark sync action in metastore failed!", e);

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -1071,6 +1071,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   public List<FileDiff> getFileDiffsByFileName(String fileName) throws MetaStoreException {
     try {
       return fileDiffDao.getByFileName(fileName);
+    } catch (EmptyResultDataAccessException e) {
+      return new ArrayList<>();
     } catch (Exception e) {
       throw new MetaStoreException(e);
     }

--- a/smart-server/src/test/java/org/smartdata/server/TestCopyScheduler.java
+++ b/smart-server/src/test/java/org/smartdata/server/TestCopyScheduler.java
@@ -35,220 +35,279 @@ import org.smartdata.server.engine.CmdletManager;
 import java.util.List;
 
 public class TestCopyScheduler extends MiniSmartClusterHarness {
- //  @Test
- //  public void appendMerge() throws Exception {
- //    waitTillSSMExitSafeMode();
- //    MetaStore metaStore = ssm.getMetaStore();
- //    SmartAdmin admin = new SmartAdmin(smartContext.getConf());
- //    CmdletManager cmdletManager = ssm.getCmdletManager();
- //    DistributedFileSystem dfs = cluster.getFileSystem();
- //    final String srcPath = "/src/";
- //    final String destPath = "/dest/";
- //    BackUpInfo backUpInfo = new BackUpInfo(1L, srcPath, destPath, 100);
- //    metaStore.insertBackUpInfo(backUpInfo);
- //    dfs.mkdirs(new Path(srcPath));
- //    dfs.mkdirs(new Path(destPath));
- //    // Write to src
- //    for (int i = 0; i < 3; i++) {
- //      // Create test files
- //      DFSTestUtil.createFile(dfs, new Path(srcPath + i), 1024, (short) 1, 1);
- //      for (int j = 0; j < 10; j++) {
- //        DFSTestUtil.appendFile(dfs, new Path(srcPath + i), 1024);
- //      }
- //    }
- //    do {
- //      Thread.sleep(1500);
- //    } while (metaStore.getPendingDiff().size() >= 30);
- //    List<FileDiff> fileDiffs = metaStore.getFileDiffs(FileDiffState.PENDING);
- //    Assert.assertTrue(fileDiffs.size() < 30);
- //  }
- //
- //  @Test
- //  public void testForceSync() throws Exception {
- //    waitTillSSMExitSafeMode();
- //    MetaStore metaStore = ssm.getMetaStore();
- //    SmartAdmin admin = new SmartAdmin(smartContext.getConf());
- //    CmdletManager cmdletManager = ssm.getCmdletManager();
- //    DistributedFileSystem dfs = cluster.getFileSystem();
- //    final String srcPath = "/src/";
- //    final String destPath = "/dest/";
- //    dfs.mkdirs(new Path(srcPath));
- //    dfs.mkdirs(new Path(destPath));
- //    // Write to src
- //    for (int i = 0; i < 3; i++) {
- //      // Create test files
- //      DFSTestUtil.createFile(dfs, new Path(srcPath + i), 1024, (short) 1, 1);
- //    }
- //    // Clear file diffs
- //    metaStore.deleteAllFileDiff();
- //    // Submit rules and trigger forceSync
- //    long ruleId = admin.submitRule(
- //        "file: every 2s | path matches \"/src/*\"| sync -dest /dest/",
- //        RuleState.ACTIVE);
- //    Thread.sleep(1000);
- //    Assert.assertTrue(metaStore.getFileDiffs(FileDiffState.PENDING).size() > 0);
- //  }
- //
- //  @Test (timeout = 60000)
- //  public void testDelete() throws Exception {
- //    waitTillSSMExitSafeMode();
- //    MetaStore metaStore = ssm.getMetaStore();
- //    CmdletManager cmdletManager = ssm.getCmdletManager();
- //    SmartAdmin admin = new SmartAdmin(smartContext.getConf());
- //    long ruleId = admin.submitRule(
- //        "file: every 2s | path matches \"/src/*\"| sync -dest /dest/",
- //        RuleState.ACTIVE);
- //    FileDiff fileDiff =
- //        new FileDiff(FileDiffType.DELETE, FileDiffState.PENDING);
- //    fileDiff.setSrc("/src/1");
- //    metaStore.insertFileDiff(fileDiff);
- //    Thread.sleep(1200);
- //    do {
- //      Thread.sleep(1000);
- //    } while (admin.getRuleInfo(ruleId).getNumCmdsGen() == 0);
- //    Assert
- //        .assertTrue(cmdletManager.listNewCreatedActions("sync", 0).size() > 0);
- //  }
- //
- //  @Test (timeout = 60000)
- //  public void testRename() throws Exception {
- //    waitTillSSMExitSafeMode();
- //    MetaStore metaStore = ssm.getMetaStore();
- //    CmdletManager cmdletManager = ssm.getCmdletManager();
- //    SmartAdmin admin = new SmartAdmin(smartContext.getConf());
- //    long ruleId = admin.submitRule(
- //        "file: every 2s | path matches \"/src/*\"| sync -dest /dest/",
- //        RuleState.ACTIVE);
- //    FileDiff fileDiff =
- //        new FileDiff(FileDiffType.RENAME, FileDiffState.PENDING);
- //    fileDiff.setSrc("/src/1");
- //    fileDiff.getParameters().put("-dest", "/src/2");
- //    metaStore.insertFileDiff(fileDiff);
- //    Thread.sleep(1200);
- //    do {
- //      Thread.sleep(1000);
- //    } while (admin.getRuleInfo(ruleId).getNumCmdsGen() == 0);
- //    Assert
- //        .assertTrue(cmdletManager.listNewCreatedActions("sync", 0).size() > 0);
- //    Thread.sleep(20000);
- //  }
- //
- // @Test (timeout = 40000)
- // public void testWithSyncRule() throws Exception {
- //   waitTillSSMExitSafeMode();
- //   MetaStore metaStore = ssm.getMetaStore();
- //   SmartAdmin admin = new SmartAdmin(smartContext.getConf());
- //   CmdletManager cmdletManager = ssm.getCmdletManager();
- //   // metaStore.deleteAllFileDiff();
- //   // metaStore.deleteAllFileInfo();
- //   // metaStore.deleteAllCmdlets();
- //   // metaStore.deleteAllActions();
- //   // metaStore.deleteAllRules();
- //   DistributedFileSystem dfs = cluster.getFileSystem();
- //   final String srcPath = "/src/";
- //   final String destPath = "/dest/";
- //   // Submit sync rule
- //   long ruleId = admin.submitRule(
- //       "file: every 1s | path matches \"/src/*\"| sync -dest " + destPath,
- //       RuleState.ACTIVE);
- //   Thread.sleep(1000);
- //   dfs.mkdirs(new Path(srcPath));
- //   dfs.mkdirs(new Path(destPath));
- //   // Write to src
- //   for (int i = 0; i < 3; i++) {
- //     // Create test files
- //     DFSTestUtil.createFile(dfs, new Path(srcPath + i), 1024, (short) 1, 1);
- //   }
- //   do {
- //     Thread.sleep(1000);
- //   } while(admin.getRuleInfo(ruleId).getNumCmdsGen() <= 2);
- //   List<ActionInfo> actionInfos = cmdletManager.listNewCreatedActions("sync", 0);
- //   Assert.assertTrue(actionInfos.size() >= 3);
- //   Thread.sleep(1200);
- //   for (int i = 0; i < 3; i++) {
- //     // Check 3 files
- //     Assert.assertTrue(dfs.exists(new Path(destPath + i)));
- //     System.out.printf("File %d is copied.\n", i);
- //   }
- // }
- //
- //
- // @Test (timeout = 60000)
- // public void testCopy() throws Exception {
- //   waitTillSSMExitSafeMode();
- //   MetaStore metaStore = ssm.getMetaStore();
- //   // metaStore.deleteAllFileDiff();
- //   // metaStore.deleteAllFileInfo();
- //   // metaStore.deleteAllCmdlets();
- //   // metaStore.deleteAllActions();
- //   DistributedFileSystem dfs = cluster.getFileSystem();
- //   final String srcPath = "/src/";
- //   final String destPath = "/dest/";
- //   BackUpInfo backUpInfo = new BackUpInfo(1L, srcPath, destPath, 100);
- //   metaStore.insertBackUpInfo(backUpInfo);
- //   dfs.mkdirs(new Path(srcPath));
- //   dfs.mkdirs(new Path(destPath));
- //   // Write to src
- //   for (int i = 0; i < 3; i++) {
- //     // Create test files
- //     DFSTestUtil.createFile(dfs, new Path(srcPath + i), 1024, (short) 1, 1);
- //   }
- //   Thread.sleep(1000);
- //   CmdletManager cmdletManager = ssm.getCmdletManager();
- //   // Submit sync action
- //   for (int i = 0; i < 3; i++) {
- //     // Create test files
- //     cmdletManager.submitCmdlet("sync -file /src/" + i + " -src " + srcPath + " -dest " + destPath);
- //   }
- //   List<ActionInfo> actionInfos = cmdletManager.listNewCreatedActions("sync", 0);
- //   Assert.assertTrue(actionInfos.size() >= 3);
- //   do {
- //     Thread.sleep(1000);
- //
- //   } while(cmdletManager.getActionsSizeInCache() + cmdletManager.getCmdletsSizeInCache() > 0);
- //   for (int i = 0; i < 3; i++) {
- //     // Write 10 files
- //     Assert.assertTrue(dfs.exists(new Path(destPath + i)));
- //     System.out.printf("File %d is copied.\n", i);
- //   }
- // }
- //
- // @Test (timeout = 40000)
- // public void testCopyDelete() throws Exception {
- //   waitTillSSMExitSafeMode();
- //   MetaStore metaStore = ssm.getMetaStore();
- //   // metaStore.deleteAllFileDiff();
- //   // metaStore.deleteAllFileInfo();
- //   // metaStore.deleteAllCmdlets();
- //   // metaStore.deleteAllActions();
- //   DistributedFileSystem dfs = cluster.getFileSystem();
- //   final String srcPath = "/src/";
- //   final String destPath = "/dest/";
- //   BackUpInfo backUpInfo = new BackUpInfo(1L, srcPath, destPath, 100);
- //   metaStore.insertBackUpInfo(backUpInfo);
- //   dfs.mkdirs(new Path(srcPath));
- //   dfs.mkdirs(new Path(destPath));
- //   // Write to src
- //   for (int i = 0; i < 3; i++) {
- //     // Create test files
- //     DFSTestUtil.createFile(dfs, new Path(srcPath + i), 1024, (short) 1, 1);
- //     dfs.delete(new Path(srcPath + i), false);
- //   }
- //
- //   Thread.sleep(2000);
- //   CmdletManager cmdletManager = ssm.getCmdletManager();
- //   // Submit sync action
- //   for (int i = 0; i < 3; i++) {
- //     // Create test files
- //     cmdletManager.submitCmdlet("sync -file /src/" + i + " -src " + srcPath + " -dest " + destPath);
- //   }
- //   List<ActionInfo> actionInfos = cmdletManager.listNewCreatedActions("sync", 0);
- //   Assert.assertTrue(actionInfos.size() >= 3);
- //   Thread.sleep(3000);
- //   for (int i = 0; i < 3; i++) {
- //     // Write 10 files
- //     Assert.assertFalse(dfs.exists(new Path(destPath + i)));
- //     System.out.printf("File %d is copied.\n", i);
- //   }
- // }
+  @Test
+  public void appendMerge() throws Exception {
+    waitTillSSMExitSafeMode();
+    MetaStore metaStore = ssm.getMetaStore();
+    SmartAdmin admin = new SmartAdmin(smartContext.getConf());
+    CmdletManager cmdletManager = ssm.getCmdletManager();
+    DistributedFileSystem dfs = cluster.getFileSystem();
+    final String srcPath = "/src/";
+    final String destPath = "/dest/";
+    BackUpInfo backUpInfo = new BackUpInfo(1L, srcPath, destPath, 100);
+    metaStore.insertBackUpInfo(backUpInfo);
+    dfs.mkdirs(new Path(srcPath));
+    dfs.mkdirs(new Path(destPath));
+    // Write to src
+    for (int i = 0; i < 3; i++) {
+      // Create test files
+      DFSTestUtil.createFile(dfs, new Path(srcPath + i), 1024, (short) 1, 1);
+      for (int j = 0; j < 10; j++) {
+        DFSTestUtil.appendFile(dfs, new Path(srcPath + i), 1024);
+      }
+    }
+    do {
+      Thread.sleep(1500);
+    } while (metaStore.getPendingDiff().size() >= 30);
+    List<FileDiff> fileDiffs = metaStore.getFileDiffs(FileDiffState.PENDING);
+    Assert.assertTrue(fileDiffs.size() < 30);
+  }
+
+  @Test
+  public void deleteMerge() throws Exception {
+    waitTillSSMExitSafeMode();
+    MetaStore metaStore = ssm.getMetaStore();
+    SmartAdmin admin = new SmartAdmin(smartContext.getConf());
+    CmdletManager cmdletManager = ssm.getCmdletManager();
+    DistributedFileSystem dfs = cluster.getFileSystem();
+    final String srcPath = "/src/";
+    final String destPath = "/dest/";
+    BackUpInfo backUpInfo = new BackUpInfo(1L, srcPath, destPath, 100);
+    metaStore.insertBackUpInfo(backUpInfo);
+    dfs.mkdirs(new Path(srcPath));
+    dfs.mkdirs(new Path(destPath));
+    // Write to src
+    for (int i = 0; i < 3; i++) {
+      // Create test files
+      DFSTestUtil.createFile(dfs, new Path(srcPath + i), 1024, (short) 1, 1);
+      dfs.delete(new Path(srcPath + i), false);
+    }
+    do {
+      Thread.sleep(1500);
+    } while (metaStore.getPendingDiff().size() >= 4);
+    List<FileDiff> fileDiffs = metaStore.getFileDiffs(FileDiffState.PENDING);
+    Assert.assertTrue(fileDiffs.size() == 3);
+  }
+
+  @Test
+  public void renameMerge() throws Exception {
+    waitTillSSMExitSafeMode();
+    MetaStore metaStore = ssm.getMetaStore();
+    SmartAdmin admin = new SmartAdmin(smartContext.getConf());
+    CmdletManager cmdletManager = ssm.getCmdletManager();
+    DistributedFileSystem dfs = cluster.getFileSystem();
+    final String srcPath = "/src/";
+    final String destPath = "/dest/";
+    BackUpInfo backUpInfo = new BackUpInfo(1L, srcPath, destPath, 100);
+    metaStore.insertBackUpInfo(backUpInfo);
+    dfs.mkdirs(new Path(srcPath));
+    dfs.mkdirs(new Path(destPath));
+    // Write to src
+    for (int i = 0; i < 3; i++) {
+      // Create test files
+      DFSTestUtil.createFile(dfs, new Path(srcPath + i), 1024, (short) 1, 1);
+      dfs.rename(new Path(srcPath + i), new Path(srcPath + i + 10));
+      // Rename target ends with 10
+      DFSTestUtil.appendFile(dfs, new Path(srcPath + i + 10), 1024);
+    }
+    do {
+      Thread.sleep(1500);
+    } while (metaStore.getPendingDiff().size() <= 9);
+    List<FileDiff> fileDiffs = metaStore.getFileDiffs(FileDiffState.PENDING);
+    for (FileDiff fileDiff: fileDiffs) {
+      if (fileDiff.getDiffType() == FileDiffType.APPEND) {
+        Assert.assertTrue(fileDiff.getSrc().endsWith("10"));
+      }
+    }
+  }
+
+
+  @Test
+  public void testForceSync() throws Exception {
+    waitTillSSMExitSafeMode();
+    MetaStore metaStore = ssm.getMetaStore();
+    SmartAdmin admin = new SmartAdmin(smartContext.getConf());
+    CmdletManager cmdletManager = ssm.getCmdletManager();
+    DistributedFileSystem dfs = cluster.getFileSystem();
+    final String srcPath = "/src/";
+    final String destPath = "/dest/";
+    dfs.mkdirs(new Path(srcPath));
+    dfs.mkdirs(new Path(destPath));
+    // Write to src
+    for (int i = 0; i < 3; i++) {
+      // Create test files
+      DFSTestUtil.createFile(dfs, new Path(srcPath + i), 1024, (short) 1, 1);
+    }
+    // Clear file diffs
+    metaStore.deleteAllFileDiff();
+    // Submit rules and trigger forceSync
+    long ruleId = admin.submitRule(
+        "file: every 2s | path matches \"/src/*\"| sync -dest /dest/",
+        RuleState.ACTIVE);
+    Thread.sleep(1000);
+    Assert.assertTrue(metaStore.getFileDiffs(FileDiffState.PENDING).size() > 0);
+  }
+
+  @Test (timeout = 60000)
+  public void testDelete() throws Exception {
+    waitTillSSMExitSafeMode();
+    MetaStore metaStore = ssm.getMetaStore();
+    CmdletManager cmdletManager = ssm.getCmdletManager();
+    SmartAdmin admin = new SmartAdmin(smartContext.getConf());
+    long ruleId = admin.submitRule(
+        "file: every 2s | path matches \"/src/*\"| sync -dest /dest/",
+        RuleState.ACTIVE);
+    FileDiff fileDiff =
+        new FileDiff(FileDiffType.DELETE, FileDiffState.PENDING);
+    fileDiff.setSrc("/src/1");
+    metaStore.insertFileDiff(fileDiff);
+    Thread.sleep(1200);
+    do {
+      Thread.sleep(1000);
+    } while (admin.getRuleInfo(ruleId).getNumCmdsGen() == 0);
+    Assert
+        .assertTrue(cmdletManager.listNewCreatedActions("sync", 0).size() > 0);
+  }
+
+  @Test (timeout = 60000)
+  public void testRename() throws Exception {
+    waitTillSSMExitSafeMode();
+    MetaStore metaStore = ssm.getMetaStore();
+    CmdletManager cmdletManager = ssm.getCmdletManager();
+    SmartAdmin admin = new SmartAdmin(smartContext.getConf());
+    long ruleId = admin.submitRule(
+        "file: every 2s | path matches \"/src/*\"| sync -dest /dest/",
+        RuleState.ACTIVE);
+    FileDiff fileDiff =
+        new FileDiff(FileDiffType.RENAME, FileDiffState.PENDING);
+    fileDiff.setSrc("/src/1");
+    fileDiff.getParameters().put("-dest", "/src/2");
+    metaStore.insertFileDiff(fileDiff);
+    Thread.sleep(1200);
+    do {
+      Thread.sleep(1000);
+    } while (admin.getRuleInfo(ruleId).getNumCmdsGen() == 0);
+    Assert
+        .assertTrue(cmdletManager.listNewCreatedActions("sync", 0).size() > 0);
+    Thread.sleep(20000);
+  }
+
+ @Test (timeout = 40000)
+ public void testWithSyncRule() throws Exception {
+   waitTillSSMExitSafeMode();
+   MetaStore metaStore = ssm.getMetaStore();
+   SmartAdmin admin = new SmartAdmin(smartContext.getConf());
+   CmdletManager cmdletManager = ssm.getCmdletManager();
+   // metaStore.deleteAllFileDiff();
+   // metaStore.deleteAllFileInfo();
+   // metaStore.deleteAllCmdlets();
+   // metaStore.deleteAllActions();
+   // metaStore.deleteAllRules();
+   DistributedFileSystem dfs = cluster.getFileSystem();
+   final String srcPath = "/src/";
+   final String destPath = "/dest/";
+   // Submit sync rule
+   long ruleId = admin.submitRule(
+       "file: every 1s | path matches \"/src/*\"| sync -dest " + destPath,
+       RuleState.ACTIVE);
+   Thread.sleep(1000);
+   dfs.mkdirs(new Path(srcPath));
+   dfs.mkdirs(new Path(destPath));
+   // Write to src
+   for (int i = 0; i < 3; i++) {
+     // Create test files
+     DFSTestUtil.createFile(dfs, new Path(srcPath + i), 1024, (short) 1, 1);
+   }
+   do {
+     Thread.sleep(1000);
+   } while(admin.getRuleInfo(ruleId).getNumCmdsGen() <= 2);
+   List<ActionInfo> actionInfos = cmdletManager.listNewCreatedActions("sync", 0);
+   Assert.assertTrue(actionInfos.size() >= 3);
+   Thread.sleep(1200);
+   for (int i = 0; i < 3; i++) {
+     // Check 3 files
+     Assert.assertTrue(dfs.exists(new Path(destPath + i)));
+     System.out.printf("File %d is copied.\n", i);
+   }
+ }
+
+
+ @Test (timeout = 60000)
+ public void testCopy() throws Exception {
+   waitTillSSMExitSafeMode();
+   MetaStore metaStore = ssm.getMetaStore();
+   // metaStore.deleteAllFileDiff();
+   // metaStore.deleteAllFileInfo();
+   // metaStore.deleteAllCmdlets();
+   // metaStore.deleteAllActions();
+   DistributedFileSystem dfs = cluster.getFileSystem();
+   final String srcPath = "/src/";
+   final String destPath = "/dest/";
+   BackUpInfo backUpInfo = new BackUpInfo(1L, srcPath, destPath, 100);
+   metaStore.insertBackUpInfo(backUpInfo);
+   dfs.mkdirs(new Path(srcPath));
+   dfs.mkdirs(new Path(destPath));
+   // Write to src
+   for (int i = 0; i < 3; i++) {
+     // Create test files
+     DFSTestUtil.createFile(dfs, new Path(srcPath + i), 1024, (short) 1, 1);
+   }
+   Thread.sleep(1000);
+   CmdletManager cmdletManager = ssm.getCmdletManager();
+   // Submit sync action
+   for (int i = 0; i < 3; i++) {
+     // Create test files
+     cmdletManager.submitCmdlet("sync -file /src/" + i + " -src " + srcPath + " -dest " + destPath);
+   }
+   List<ActionInfo> actionInfos = cmdletManager.listNewCreatedActions("sync", 0);
+   Assert.assertTrue(actionInfos.size() >= 3);
+   do {
+     Thread.sleep(1000);
+
+   } while(cmdletManager.getActionsSizeInCache() + cmdletManager.getCmdletsSizeInCache() > 0);
+   for (int i = 0; i < 3; i++) {
+     // Write 10 files
+     Assert.assertTrue(dfs.exists(new Path(destPath + i)));
+     System.out.printf("File %d is copied.\n", i);
+   }
+ }
+
+ @Test (timeout = 40000)
+ public void testCopyDelete() throws Exception {
+   waitTillSSMExitSafeMode();
+   MetaStore metaStore = ssm.getMetaStore();
+   // metaStore.deleteAllFileDiff();
+   // metaStore.deleteAllFileInfo();
+   // metaStore.deleteAllCmdlets();
+   // metaStore.deleteAllActions();
+   DistributedFileSystem dfs = cluster.getFileSystem();
+   final String srcPath = "/src/";
+   final String destPath = "/dest/";
+   BackUpInfo backUpInfo = new BackUpInfo(1L, srcPath, destPath, 100);
+   metaStore.insertBackUpInfo(backUpInfo);
+   dfs.mkdirs(new Path(srcPath));
+   dfs.mkdirs(new Path(destPath));
+   // Write to src
+   for (int i = 0; i < 3; i++) {
+     // Create test files
+     DFSTestUtil.createFile(dfs, new Path(srcPath + i), 1024, (short) 1, 1);
+     dfs.delete(new Path(srcPath + i), false);
+   }
+
+   Thread.sleep(2000);
+   CmdletManager cmdletManager = ssm.getCmdletManager();
+   // Submit sync action
+   for (int i = 0; i < 3; i++) {
+     // Create test files
+     cmdletManager.submitCmdlet("sync -file /src/" + i + " -src " + srcPath + " -dest " + destPath);
+   }
+   List<ActionInfo> actionInfos = cmdletManager.listNewCreatedActions("sync", 0);
+   Assert.assertTrue(actionInfos.size() >= 3);
+   Thread.sleep(3000);
+   for (int i = 0; i < 3; i++) {
+     // Write 10 files
+     Assert.assertFalse(dfs.exists(new Path(destPath + i)));
+     System.out.printf("File %d is copied.\n", i);
+   }
+ }
 }

--- a/smart-server/src/test/java/org/smartdata/server/TestCopyScheduler.java
+++ b/smart-server/src/test/java/org/smartdata/server/TestCopyScheduler.java
@@ -86,7 +86,8 @@ public class TestCopyScheduler extends MiniSmartClusterHarness {
       Thread.sleep(1500);
     } while (metaStore.getPendingDiff().size() >= 4);
     List<FileDiff> fileDiffs = metaStore.getFileDiffs(FileDiffState.PENDING);
-    Assert.assertTrue(fileDiffs.size() == 3);
+    // File is not created, so clear all fileDiff
+    Assert.assertTrue(fileDiffs.size() == 0);
   }
 
   @Test


### PR DESCRIPTION
* Move baseSync from FileCopyDrPlugin to CopyScheduler.
* Handle failed tasks by triggering a directSync (from primary to remote HDFS).
* Enable TestCopyScheduler.
* Add a new FileDiffState: FAILED(5).
