### PR TITLE
Fix #1172, add batch Support for baseSync

### DIFF
--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -67,6 +67,8 @@ public class CopyScheduler extends ActionSchedulerService {
   private Map<String, ScheduleTask.FileChain> fileDiffChainMap;
   // <did, Fail times>
   private Map<Long, Integer> fileDiffMap;
+  // BaseSync queue
+  private Map<String, String> baseSyncQueue;
   // Merge append length threshold
   private long mergeLenTh = DFSConfigKeys.DFS_BLOCK_SIZE_DEFAULT * 3;
   // Merge count length threshold
@@ -80,6 +82,7 @@ public class CopyScheduler extends ActionSchedulerService {
     this.actionDiffMap = new ConcurrentHashMap<>();
     this.fileDiffChainMap = new HashMap<>();
     this.fileDiffMap = new ConcurrentHashMap<>();
+    this.baseSyncQueue = new ConcurrentHashMap<>();
     this.executorService = Executors.newSingleThreadScheduledExecutor();
   }
 
@@ -223,6 +226,10 @@ public class CopyScheduler extends ActionSchedulerService {
         LOG.error("Sync action error", e);
       }
     }
+  }
+
+  private void batchDirectSync() throws MetaStoreException {
+    
   }
 
   private void baseSync(String srcDir, String destDir) throws MetaStoreException {

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -240,9 +240,10 @@ public class CopyScheduler extends ActionSchedulerService {
 
   private void batchDirectSync() throws MetaStoreException {
     long currentTime;
-    // Use half of check interval to batchSync
-    long maxCheckTime = System.currentTimeMillis() + checkInterval / 2;
+    // Use 90% of check interval to batchSync
+    long maxCheckTime = System.currentTimeMillis() + checkInterval * 9 / 10;
     if (baseSyncQueue.size() == 0) {
+      LOG.info("Base Sync size = 0! All files are Synced");
       return;
     }
     for (Iterator<Map.Entry<String, String>> it = baseSyncQueue.entrySet().iterator(); it.hasNext();) {
@@ -258,6 +259,7 @@ public class CopyScheduler extends ActionSchedulerService {
 
   private void baseSync(String srcDir, String destDir) throws MetaStoreException {
     List<FileInfo> srcFiles = metaStore.getFilesByPrefix(srcDir);
+    LOG.debug("Base Sync {} files", srcFiles.size());
     for (FileInfo fileInfo : srcFiles) {
       if (fileInfo.isdir()) {
         // Ignore directory

--- a/smart-server/src/test/java/org/smartdata/server/TestCopyScheduler.java
+++ b/smart-server/src/test/java/org/smartdata/server/TestCopyScheduler.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
 import org.smartdata.admin.SmartAdmin;
 import org.smartdata.metastore.MetaStore;
 import org.smartdata.model.ActionInfo;
@@ -31,10 +30,10 @@ import org.smartdata.model.BackUpInfo;
 import org.smartdata.model.FileDiff;
 import org.smartdata.model.FileDiffState;
 import org.smartdata.model.FileDiffType;
+import org.smartdata.model.FileInfo;
 import org.smartdata.model.RuleState;
 import org.smartdata.server.engine.CmdletManager;
 
-import java.io.File;
 import java.util.List;
 
 public class TestCopyScheduler extends MiniSmartClusterHarness {
@@ -181,6 +180,32 @@ public class TestCopyScheduler extends MiniSmartClusterHarness {
   //   Assert.assertTrue(metaStore.getFileDiffs(FileDiffState.PENDING).size() > 0);
   // }
   //
+  // @Test(timeout = 40000)
+  // public void batchSync() throws Exception {
+  //   waitTillSSMExitSafeMode();
+  //   MetaStore metaStore = ssm.getMetaStore();
+  //   SmartAdmin admin = new SmartAdmin(smartContext.getConf());
+  //   CmdletManager cmdletManager = ssm.getCmdletManager();
+  //   DistributedFileSystem dfs = cluster.getFileSystem();
+  //   final String srcPath = "/src/";
+  //   final String destPath = "/dest/";
+  //   FileInfo fileInfo;
+  //   long now = System.currentTimeMillis();
+  //   for (int i = 0; i < 100; i++) {
+  //     fileInfo = new FileInfo(srcPath + i, i,  1024, false, (short)3,
+  //         1024, now, now, (short) 1, null, null, (byte)3);
+  //     metaStore.insertFile(fileInfo);
+  //     Thread.sleep(100);
+  //   }
+  //   long ruleId =
+  //       admin.submitRule(
+  //           "file: every 2s | path matches \"/src/*\"| sync -dest /dest/", RuleState.ACTIVE);
+  //   Thread.sleep(2200);
+  //   do {
+  //     Thread.sleep(1000);
+  //   } while (admin.getRuleInfo(ruleId).getNumCmdsGen() <= 30);
+  // }
+  //
   // @Test(timeout = 60000)
   // public void testDelete() throws Exception {
   //   waitTillSSMExitSafeMode();
@@ -251,6 +276,7 @@ public class TestCopyScheduler extends MiniSmartClusterHarness {
   //   Thread.sleep(1000);
   //   FileStatus fileStatus = dfs.getFileStatus(new Path(destPath + 1));
   //   Assert.assertTrue(fileStatus.getLen() == 1024);
+  //   // TODO 777->551
   //   Assert.assertTrue(fileStatus.getPermission().toShort() == (short) 551);
   // }
   //


### PR DESCRIPTION
Basic solution/idea (Async process file list):
1. Add all files to memory (very fast).
2. Batch (default size = 15) insert diffs into metastore (slow due to metastore and network).
3. Processing file diffs when diffs are in metastore (fast).