### PR TITLE
Fix #1228, loading pending cmdlets after restart SSM

### DIFF
--- a/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
@@ -169,19 +169,22 @@ public class CmdletManager extends AbstractService {
       } else {
         try {
           actionInfos = metaStore.getActions(cmdletInfo.getAids());
+          actionsInDB = true;
         } catch (MetaStoreException e) {
           LOG.error("Get aids -> [ {} ] from database error!",
-              cmdletInfo.getAids());
+              cmdletInfo.getAids(), e);
+        }
+        if (!actionsInDB || actionInfos.size() == 0) {
           cmdletInfo.setState(CmdletState.FAILED);
           try {
             metaStore.updateCmdlet(cmdletInfo);
           } catch (MetaStoreException e1) {
             LOG.error("Mark cmdletinfo ->[ {} ] as failed error!",
-                cmdletInfo.getParameters(), e);
+                cmdletInfo.getParameters(), e1);
           }
-          continue;
         }
-        actionsInDB = true;
+        continue;
+
       }
       LOG.debug(String.format("Received Cmdlet -> [ %s ]",
           cmdletDescriptor.getCmdletString()));

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -733,7 +733,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
 
-  public synchronized void insertCmdletsTable(CmdletInfo[] commands)
+  public synchronized void insertCmdlets(CmdletInfo[] commands)
       throws MetaStoreException {
     try {
       cmdletDao.insert(commands);
@@ -742,10 +742,15 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
     }
   }
 
-  public synchronized void insertCmdletTable(CmdletInfo command)
+  public synchronized void insertCmdlet(CmdletInfo command)
       throws MetaStoreException {
     try {
-      cmdletDao.insert(command);
+      // Update if exists
+      if (cmdletDao.getById(command.getCid()) != null) {
+        cmdletDao.update(command);
+      } else {
+        cmdletDao.insert(command);
+      }
     } catch (Exception e) {
       throw new MetaStoreException(e);
     }
@@ -776,6 +781,25 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
       return cmdletDao.getByCondition(cidCondition, ridCondition, state);
     } catch (EmptyResultDataAccessException e) {
       return new ArrayList<>();
+    } catch (Exception e) {
+      throw new MetaStoreException(e);
+    }
+  }
+
+  public List<CmdletInfo> getCmdlets(CmdletState state) throws MetaStoreException {
+    try {
+      return cmdletDao.getByState(state);
+    } catch (EmptyResultDataAccessException e) {
+      return new ArrayList<>();
+    } catch (Exception e) {
+      throw new MetaStoreException(e);
+    }
+  }
+
+  public boolean updateCmdlet(CmdletInfo cmdletInfo)
+      throws MetaStoreException {
+    try {
+      return cmdletDao.update(cmdletInfo) >= 0;
     } catch (Exception e) {
       throw new MetaStoreException(e);
     }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -746,7 +746,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
       throws MetaStoreException {
     try {
       // Update if exists
-      if (cmdletDao.getById(command.getCid()) != null) {
+      if (getCmdletById(command.getCid()) != null) {
         cmdletDao.update(command);
       } else {
         cmdletDao.insert(command);

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/CmdletDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/CmdletDao.java
@@ -72,6 +72,12 @@ public class CmdletDao {
         new Object[]{rid}, new CmdletRowMapper());
   }
 
+  public List<CmdletInfo> getByState(CmdletState state) {
+    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE state = ?",
+        new Object[]{state.getValue()}, new CmdletRowMapper());
+  }
+
   public List<CmdletInfo> getByCondition(String cidCondition,
       String ridCondition, CmdletState state) {
     JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestMetaStore.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestMetaStore.java
@@ -326,7 +326,7 @@ public class TestMetaStore extends TestDaoUtil {
     CmdletInfo cmdletInfo = new CmdletInfo(1, ruleInfo.getId(),
         CmdletState.EXECUTING, "test", 123123333l, 232444444l);
     cmdletInfo.setAids(Collections.singletonList(1l));
-    metaStore.insertCmdletTable(cmdletInfo);
+    metaStore.insertCmdlet(cmdletInfo);
     metaStore.insertAction(new ActionInfo(1, 1,
         "allssd", args, "Test",
         "Test", true, 123213213l, true, 123123l,
@@ -443,10 +443,10 @@ public class TestMetaStore extends TestDaoUtil {
   public void testInsertCmdletsTable() throws Exception {
     CmdletInfo command1 = new CmdletInfo(0, 1,
         CmdletState.EXECUTING, "test", 123123333l, 232444444l);
-    metaStore.insertCmdletTable(command1);
+    metaStore.insertCmdlet(command1);
     CmdletInfo command2 = new CmdletInfo(1, 78,
         CmdletState.PAUSED, "tt", 123178333l, 232444994l);
-    metaStore.insertCmdletTable(command2);
+    metaStore.insertCmdlet(command2);
     Assert.assertTrue(metaStore.getCmdletById(command1.getCid()).equals(command1));
     Assert.assertTrue(metaStore.getCmdletById(command2.getCid()).equals(command2));
     metaStore.updateCmdlet(command1.getCid(), "TestParameter", CmdletState.DRYRUN);
@@ -464,7 +464,7 @@ public class TestMetaStore extends TestDaoUtil {
     CmdletInfo command2 = new CmdletInfo(1, 78,
         CmdletState.PENDING, "tt", 123178333l, 232444994l);
     CmdletInfo[] commands = {command1, command2};
-    metaStore.insertCmdletsTable(commands);
+    metaStore.insertCmdlets(commands);
     commandId = metaStore.getMaxCmdletId();
     String cidCondition = ">= 1 ";
     String ridCondition = "= 78 ";

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestActionDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestActionDao.java
@@ -51,25 +51,25 @@ public class TestActionDao extends TestDaoUtil {
 
   @Test
   public void testInsertGetAction() throws Exception {
-    Map<String, String> args = new HashMap();
+    Map<String, String> args = new HashMap<>();
     ActionInfo actionInfo = new ActionInfo(1, 1,
         "cache", args, "Test",
-        "Test", false, 123213213l, true, 123123l,
+        "Test", false, 123213213L, true, 123123L,
         100);
     actionDao.insert(new ActionInfo[]{actionInfo});
     ActionInfo dbActionInfo = actionDao.getById(1l);
     Assert.assertTrue(actionInfo.equals(dbActionInfo));
     // Get wrong id
     expectedException.expect(EmptyResultDataAccessException.class);
-    actionDao.getById(100l);
+    actionDao.getById(100L);
   }
 
   @Test
   public void testUpdateAction() throws Exception {
-    Map<String, String> args = new HashMap();
+    Map<String, String> args = new HashMap<>();
     ActionInfo actionInfo = new ActionInfo(1, 1,
         "cache", args, "Test",
-        "Test", false, 123213213l, true, 123123l,
+        "Test", false, 123213213L, true, 123123L,
         100);
     actionDao.insert(actionInfo);
     actionInfo.setSuccessful(true);
@@ -80,10 +80,10 @@ public class TestActionDao extends TestDaoUtil {
 
   @Test
   public void testGetNewDeleteAction() throws Exception {
-    Map<String, String> args = new HashMap();
+    Map<String, String> args = new HashMap<>();
     ActionInfo actionInfo = new ActionInfo(1, 1,
         "cache", args, "Test",
-        "Test", false, 123213213l, true, 123123l,
+        "Test", false, 123213213L, true, 123123L,
         100);
     List<ActionInfo> actionInfoList = actionDao.getLatestActions(0);
     // Get from empty table
@@ -93,7 +93,7 @@ public class TestActionDao extends TestDaoUtil {
     actionDao.insert(actionInfo);
     actionInfoList = actionDao.getLatestActions(0);
     Assert.assertTrue(actionInfoList.size() == 2);
-    actionInfoList = actionDao.getByIds(Arrays.asList(new Long[]{1l, 2l}));
+    actionInfoList = actionDao.getByIds(Arrays.asList(1l, 2l));
     Assert.assertTrue(actionInfoList.size() == 2);
     actionDao.delete(actionInfo.getActionId());
     actionInfoList = actionDao.getAll();
@@ -116,7 +116,7 @@ public class TestActionDao extends TestDaoUtil {
     actionDao.insert(actionInfo);
     actionInfoList = actionDao.getLatestActions("cache", 0, false, true);
     Assert.assertTrue(actionInfoList.size() == 2);
-    actionInfoList = actionDao.getByIds(Arrays.asList(new Long[]{1l, 2l}));
+    actionInfoList = actionDao.getByIds(Arrays.asList(1L, 2L));
     Assert.assertTrue(actionInfoList.size() == 2);
     actionInfoList = actionDao.getLatestActions("cache", 1, false, true);
     Assert.assertTrue(actionInfoList.size() == 1);
@@ -127,7 +127,7 @@ public class TestActionDao extends TestDaoUtil {
     Map<String, String> args = new HashMap<>();
     ActionInfo actionInfo = new ActionInfo(1, 1,
         "cache", args, "Test",
-        "Test", false, 123213213l, true, 123123l,
+        "Test", false, 123213213L, true, 123123L,
         100);
     List<ActionInfo> actionInfoList =
         actionDao.getLatestActions("cache", 0);
@@ -138,7 +138,7 @@ public class TestActionDao extends TestDaoUtil {
     actionDao.insert(actionInfo);
     actionInfoList = actionDao.getLatestActions("cache", 0, true);
     Assert.assertTrue(actionInfoList.size() == 2);
-    actionInfoList = actionDao.getByIds(Arrays.asList(new Long[]{1l, 2l}));
+    actionInfoList = actionDao.getByIds(Arrays.asList(1L, 2L));
     Assert.assertTrue(actionInfoList.size() == 2);
     actionInfoList = actionDao.getLatestActions("cache", 1, true);
     Assert.assertTrue(actionInfoList.size() == 1);
@@ -149,7 +149,7 @@ public class TestActionDao extends TestDaoUtil {
     Map<String, String> args = new HashMap<>();
     ActionInfo actionInfo = new ActionInfo(1, 1,
         "cache", args, "Test",
-        "Test", false, 123213213l, true, 123123l,
+        "Test", false, 123213213L, true, 123123L,
         100);
     List<ActionInfo> actionInfoList =
         actionDao.getLatestActions("cache", false, 0);
@@ -160,7 +160,7 @@ public class TestActionDao extends TestDaoUtil {
     actionDao.insert(actionInfo);
     actionInfoList = actionDao.getLatestActions("cache", false, 0);
     Assert.assertTrue(actionInfoList.size() == 2);
-    actionInfoList = actionDao.getByIds(Arrays.asList(new Long[]{1l, 2l}));
+    actionInfoList = actionDao.getByIds(Arrays.asList(1L, 2L));
     Assert.assertTrue(actionInfoList.size() == 2);
     actionInfoList = actionDao.getLatestActions("cache", false, 1);
     Assert.assertTrue(actionInfoList.size() == 1);
@@ -169,10 +169,10 @@ public class TestActionDao extends TestDaoUtil {
 
   @Test
   public void testMaxId() throws Exception {
-    Map<String, String> args = new HashMap();
+    Map<String, String> args = new HashMap<>();
     ActionInfo actionInfo = new ActionInfo(1, 1,
         "cache", args, "Test",
-        "Test", false, 123213213l, true, 123123l,
+        "Test", false, 123213213L, true, 123123L,
         100);
     Assert.assertTrue(actionDao.getMaxId() == 0);
     actionDao.insert(actionInfo);

--- a/smart-server/src/test/java/org/smartdata/server/engine/TestCmdletManager.java
+++ b/smart-server/src/test/java/org/smartdata/server/engine/TestCmdletManager.java
@@ -200,4 +200,23 @@ public class TestCmdletManager extends MiniSmartClusterHarness {
 
     cmdletManager.stop();
   }
+
+  @Test
+  public void testLoadingPendingCmdlets() throws Exception {
+    waitTillSSMExitSafeMode();
+
+
+    CmdletManager cmdletManager = ssm.getCmdletManager();
+    cmdletManager.stop();
+
+    MetaStore metaStore = ssm.getMetaStore();
+    CmdletDescriptor cmdletDescriptor = generateCmdletDescriptor();
+    CmdletInfo cmdletInfo = new CmdletInfo(0, cmdletDescriptor.getRuleId(),
+        CmdletState.PENDING, cmdletDescriptor.getCmdletString(),
+        123178333l, 232444994l);
+    CmdletInfo[] cmdlets = {cmdletInfo};
+    metaStore.insertCmdlets(cmdlets);
+    cmdletManager.init();
+    Assert.assertEquals(1, cmdletManager.getCmdletsSizeInCache());
+  }
 }

--- a/smart-server/src/test/java/org/smartdata/server/engine/TestCmdletManager.java
+++ b/smart-server/src/test/java/org/smartdata/server/engine/TestCmdletManager.java
@@ -128,7 +128,7 @@ public class TestCmdletManager extends MiniSmartClusterHarness {
       CmdletState.PENDING, cmdletDescriptor.getCmdletString(),
       123178333l, 232444994l);
     CmdletInfo[] cmdlets = {cmdletInfo};
-    metaStore.insertCmdletsTable(cmdlets);
+    metaStore.insertCmdlets(cmdlets);
 
     CmdletManager cmdletManager = ssm.getCmdletManager();
     Assert.assertTrue(cmdletManager.listCmdletsInfo(1, null).size() == 1);
@@ -164,7 +164,7 @@ public class TestCmdletManager extends MiniSmartClusterHarness {
 
     cmdletManager.start();
     cmdletManager.submitCmdlet("hello");
-    verify(metaStore, times(1)).insertCmdletTable(any(CmdletInfo.class));
+    verify(metaStore, times(1)).insertCmdlet(any(CmdletInfo.class));
     verify(metaStore, times(1)).insertActions(any(ActionInfo[].class));
 
     Assert.assertEquals(1, cmdletManager.getCmdletsSizeInCache());

--- a/smart-server/src/test/java/org/smartdata/server/engine/cmdlet/TestCmdletExecutor.java
+++ b/smart-server/src/test/java/org/smartdata/server/engine/cmdlet/TestCmdletExecutor.java
@@ -195,7 +195,7 @@
 //        CmdletState.PENDING, cmdletDescriptor.getCmdletString(),
 //        123178333l, 232444994l);
 //    CmdletInfo[] cmdlets = {cmdletInfo};
-//    metaStore.insertCmdletsTable(cmdlets);
+//    metaStore.insertCmdlets(cmdlets);
 //  }
 //
 //  private void testCmdletExecutorHelper() throws Exception {


### PR DESCRIPTION
* Fix #1228, loading pending cmdlets after restart SSM.
* Rename insertCmdletsTable and insertCmdletTable to insertCmdlets and insertCmdlet.
* Refine submitCmdlet in CmdletManager.
* Add private void cmdletFinished(CmdletInfo cmdletInfo) to CmdletManager.