### PR TITLE
Fix reloading stale cmdlets and actions

### DIFF
--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletDispatcher.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletDispatcher.java
@@ -68,7 +68,7 @@ public class CmdletDispatcher {
       selected.execute(cmdlet);
       LOG.info(
           String.format(
-              "Dispatching cmdlet %s to executor service %s",
+              "Dispatching cmdlet->[%s] to executor service %s",
               cmdlet.getCmdletId(), selected.getClass()));
       index += 1;
     }

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -589,7 +589,7 @@ public class CopyScheduler extends ActionSchedulerService {
     private void diffPreProcessing(
         List<FileDiff> fileDiffs) throws MetaStoreException {
       // Merge all existing fileDiffs into fileChains
-      LOG.debug("Size of Pending diffs", fileDiffs.size());
+      LOG.debug("Size of Pending diffs {}", fileDiffs.size());
       if (fileDiffs.size() == 0 && baseSyncQueue.size() == 0) {
         LOG.debug("All Backup directories are synced");
         return;

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -889,6 +889,28 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
     }
   }
 
+  public void markActionFailed(long aid) throws MetaStoreException {
+    ActionInfo actionInfo = getActionById(aid);
+    if (actionInfo != null) {
+      actionInfo.setSuccessful(false);
+      actionInfo.setProgress(1);
+      actionInfo.setFinishTime(actionInfo.getCreateTime());
+      updateAction(actionInfo);
+    }
+  }
+
+  public void updateAction(ActionInfo actionInfo) throws MetaStoreException {
+    if (actionInfo == null) {
+      return;
+    }
+    LOG.debug("Update Action ID {}", actionInfo.getActionId());
+    try {
+      actionDao.update(actionInfo);
+    } catch (Exception e) {
+      throw new MetaStoreException(e);
+    }
+  }
+
   public synchronized void updateActions(ActionInfo[] actionInfos)
       throws MetaStoreException {
     if (actionInfos == null || actionInfos.length == 0) {

--- a/smart-server/src/test/java/org/smartdata/server/engine/TestCmdletManager.java
+++ b/smart-server/src/test/java/org/smartdata/server/engine/TestCmdletManager.java
@@ -218,7 +218,8 @@ public class TestCmdletManager extends MiniSmartClusterHarness {
     metaStore.insertCmdlets(cmdlets);
     // init cmdletmanager
     cmdletManager.init();
-    Assert.assertEquals(1, cmdletManager.getCmdletsSizeInCache());
+    Thread.sleep(1000);
+    Assert.assertTrue(metaStore.getCmdletById(0).getState() == CmdletState.FAILED);
   }
 
   @Test


### PR DESCRIPTION
* Mark stale cmdlets and actions as failed. Note that if these cmdlets and actions are trigger by rules, they may be re-submitted.  