### PR TITLE
Solve #1487, add namespace fetcher batch into smart-default.xml

### DIFF
--- a/conf/smart-default.xml
+++ b/conf/smart-default.xml
@@ -62,6 +62,12 @@
   </property>
 
   <property>
+    <name>smart.namespace.batch</name>
+    <value>200</value>
+    <description>Batch number of Namespace (Inotify) consumer batch</description>
+  </property>
+
+  <property>
     <name>smart.rule.executors</name>
     <value>5</value>
     <description>Max number of rules that can be executed in parallel</description>

--- a/conf/smart-default.xml
+++ b/conf/smart-default.xml
@@ -62,9 +62,9 @@
   </property>
 
   <property>
-    <name>smart.namespace.batch</name>
+    <name>smart.namespace.fetcher.batch</name>
     <value>500</value>
-    <description>Batch number of Namespace (Inotify) consumer batch</description>
+    <description>Batch size of Namespace fetcher</description>
   </property>
 
   <property>

--- a/conf/smart-default.xml
+++ b/conf/smart-default.xml
@@ -63,7 +63,7 @@
 
   <property>
     <name>smart.namespace.batch</name>
-    <value>200</value>
+    <value>500</value>
     <description>Batch number of Namespace (Inotify) consumer batch</description>
   </property>
 

--- a/conf/smart-default.xml
+++ b/conf/smart-default.xml
@@ -68,6 +68,12 @@
   </property>
 
   <property>
+    <name>smart.cmdlet.executors</name>
+    <value>40</value>
+    <description>Max number of cmdlets that can be executed in parallel on agent</description>
+  </property>
+
+  <property>
     <name>smart.action.local.execution.disabled</name>
     <value>false</value>
     <description>Actions will not be executed on SSM server if true.</description>

--- a/smart-alluxio-support/smart-alluxio/src/main/java/org/smartdata/alluxio/metric/fetcher/AlluxioNamespaceFetcher.java
+++ b/smart-alluxio-support/smart-alluxio/src/main/java/org/smartdata/alluxio/metric/fetcher/AlluxioNamespaceFetcher.java
@@ -111,7 +111,7 @@ public class AlluxioNamespaceFetcher {
             LOG.error("Current batch actual size = "
                 + currentBatch.actualSize(), e);
           }
-          this.currentBatch = new FileInfoBatch(DEFAULT_BATCH_SIZE);
+          this.currentBatch = new FileInfoBatch(defaultBatchSize);
         }
 
         if (this.batches.isEmpty()) {

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
@@ -32,7 +32,8 @@ public class SmartConfKeys {
 
   public static final String SMART_SERVICE_MODE_KEY = "smart.service.mode";
   public static final String SMART_SERVICE_MODE_DEFAULT = "HDFS";
-  public static final String SMART_NAMESPACE_BATCH = "smart.namespace.batch";
+  public static final String SMART_NAMESPACE_FETCHER_BATCH_KEY = "smart.namespace.fetcher.batch";
+  public static final int SMART_NAMESPACE_FETCHER_BATCH_DEFAULT = 500;
 
   public static final String SMART_DFS_NAMENODE_RPCSERVER_KEY = "smart.dfs.namenode.rpcserver";
 

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
@@ -70,7 +70,7 @@ public class SmartConfKeys {
   public static final int SMART_RULE_EXECUTORS_DEFAULT = 5;
 
   public static final String SMART_CMDLET_EXECUTORS_KEY = "smart.cmdlet.executors";
-  public static final int SMART_CMDLET_EXECUTORS_DEFAULT = 10;
+  public static final int SMART_CMDLET_EXECUTORS_DEFAULT = 40;
 
   // Keep it only for test
   public static final String SMART_ENABLE_ZEPPELIN_WEB = "smart.zeppelin.web.enable";

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
@@ -32,6 +32,7 @@ public class SmartConfKeys {
 
   public static final String SMART_SERVICE_MODE_KEY = "smart.service.mode";
   public static final String SMART_SERVICE_MODE_DEFAULT = "HDFS";
+  public static final String SMART_NAMESPACE_BATCH = "smart.namespace.batch";
 
   public static final String SMART_DFS_NAMENODE_RPCSERVER_KEY = "smart.dfs.namenode.rpcserver";
 

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/NamespaceFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/NamespaceFetcher.java
@@ -137,7 +137,7 @@ public class NamespaceFetcher {
       this.client = client;
       this.conf = conf;
       String configString = conf.get(SmartConfKeys.SMART_IGNORE_DIRS_KEY);
-      defaultBatchSize = conf.getInt(SmartConfKeys.SMART_NAMESPACE_BATCH, 20);
+      defaultBatchSize = conf.getInt(SmartConfKeys.SMART_NAMESPACE_BATCH, 200);
       if (configString == null){
         configString = "";
       }
@@ -156,6 +156,7 @@ public class NamespaceFetcher {
       this.client = client;
       this.conf = new SmartConf();
       String configString = conf.get(SmartConfKeys.SMART_IGNORE_DIRS_KEY);
+      defaultBatchSize = conf.getInt(SmartConfKeys.SMART_NAMESPACE_BATCH, 200);
       if (configString == null){
         configString = "";
       }

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/NamespaceFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/NamespaceFetcher.java
@@ -17,7 +17,6 @@
  */
 package org.smartdata.hdfs.metric.fetcher;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.protocol.DirectoryListing;
 import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
@@ -138,6 +137,7 @@ public class NamespaceFetcher {
       this.client = client;
       this.conf = conf;
       String configString = conf.get(SmartConfKeys.SMART_IGNORE_DIRS_KEY);
+      defaultBatchSize = conf.getInt(SmartConfKeys.SMART_NAMESPACE_BATCH, 20);
       if (configString == null){
         configString = "";
       }
@@ -186,7 +186,7 @@ public class NamespaceFetcher {
             LOG.error("Current batch actual size = "
                 + currentBatch.actualSize(), e);
           }
-          this.currentBatch = new FileInfoBatch(DEFAULT_BATCH_SIZE);
+          this.currentBatch = new FileInfoBatch(defaultBatchSize);
         }
 
         if (this.batches.isEmpty()) {

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/NamespaceFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/NamespaceFetcher.java
@@ -137,7 +137,9 @@ public class NamespaceFetcher {
       this.client = client;
       this.conf = conf;
       String configString = conf.get(SmartConfKeys.SMART_IGNORE_DIRS_KEY);
-      defaultBatchSize = conf.getInt(SmartConfKeys.SMART_NAMESPACE_BATCH, 200);
+      defaultBatchSize = conf.getInt(SmartConfKeys
+              .SMART_NAMESPACE_FETCHER_BATCH_KEY,
+          SmartConfKeys.SMART_NAMESPACE_FETCHER_BATCH_DEFAULT);
       if (configString == null){
         configString = "";
       }
@@ -156,7 +158,9 @@ public class NamespaceFetcher {
       this.client = client;
       this.conf = new SmartConf();
       String configString = conf.get(SmartConfKeys.SMART_IGNORE_DIRS_KEY);
-      defaultBatchSize = conf.getInt(SmartConfKeys.SMART_NAMESPACE_BATCH, 200);
+      defaultBatchSize = conf.getInt(SmartConfKeys
+          .SMART_NAMESPACE_FETCHER_BATCH_KEY,
+          SmartConfKeys.SMART_NAMESPACE_FETCHER_BATCH_DEFAULT);
       if (configString == null){
         configString = "";
       }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/ingestion/IngestionTask.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/ingestion/IngestionTask.java
@@ -28,7 +28,8 @@ public abstract class IngestionTask implements Runnable {
   public static long numDirectoriesFetched = 0L;
   public static long numPersisted = 0L;
 
-  protected static final int DEFAULT_BATCH_SIZE = 20;
+  protected int defaultBatchSize = 20;
+
   protected static final String ROOT = "/";
   // Deque for Breadth-First-Search
   protected ArrayDeque<String> deque;
@@ -43,7 +44,7 @@ public abstract class IngestionTask implements Runnable {
   public IngestionTask() {
     this.deque = new ArrayDeque<>();
     this.batches = new LinkedBlockingDeque<>();
-    this.currentBatch = new FileInfoBatch(DEFAULT_BATCH_SIZE);
+    this.currentBatch = new FileInfoBatch(defaultBatchSize);
     this.deque.add(ROOT);
   }
   public boolean finished() {
@@ -58,7 +59,7 @@ public abstract class IngestionTask implements Runnable {
     this.currentBatch.add(status);
     if (this.currentBatch.isFull()) {
       this.batches.put(currentBatch);
-      this.currentBatch = new FileInfoBatch(DEFAULT_BATCH_SIZE);
+      this.currentBatch = new FileInfoBatch(defaultBatchSize);
     }
   }
 }


### PR DESCRIPTION
* Add `smart.namespace.fetcher.batch` to `smart-default.xml` for batch size of namespace fetcher. Increase this parameter will greatly reduce namespace fetching time and speed up SSM start time.  
* Add `smart.cmdlet.executors` to `smart-default.xml` for max number of cmdlet  in parallel on each agent. A larger value of this parameter leads to more parallelism on each agent.