### PR TITLE
Solve #1520, fix truncate0 inotify issue

### DIFF
--- a/smart-hadoop-support/smart-hadoop-2.7/src/main/java/org/smartdata/hdfs/CompatibilityHelper27.java
+++ b/smart-hadoop-support/smart-hadoop-2.7/src/main/java/org/smartdata/hdfs/CompatibilityHelper27.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.SmartInputStreamFactory;
@@ -169,39 +170,45 @@ public class CompatibilityHelper27 implements CompatibilityHelper {
 
   @Override
   public boolean setLen2Zero(DFSClient client, String src) throws IOException {
-    //Delete file and create file
-    //save the metadata
+    // return client.truncate(src, 0);
+    // Delete file and create file
+    // Save the metadata
     HdfsFileStatus fileStatus = client.getFileInfo(src);
-    //delete file
+    AclStatus aclStatus = client.getAclStatus(src);
+    // Delete file
     client.delete(src, true);
-    //create file
+    // Create file
     client.create(src, true);
-    //set metadata
+    // Set metadata
     client.setOwner(src, fileStatus.getOwner(), fileStatus.getGroup());
     client.setPermission(src, fileStatus.getPermission());
     client.setReplication(src, fileStatus.getReplication());
-    // TODO set Storagepolicy
     client.setStoragePolicy(src, "Cold");
-    // client.setTimes(src, fileStatus.getAccessTime(), client.getFileInfo(src).getModificationTime());
+    client.setTimes(src, fileStatus.getAccessTime(),
+        client.getFileInfo(src).getModificationTime());
+    client.setAcl(src, aclStatus.getEntries());
     return true;
   }
 
   @Override
   public boolean setLen2Zero(DistributedFileSystem fileSystem, String src) throws IOException {
-    //Delete file and create file
-    //save the metadata
+    // return fileSystem.truncate(new Path(src), 0);
+    // Delete file and create file
+    // Save the metadata
     FileStatus fileStatus = fileSystem.getFileStatus(new Path(src));
-    //delete file
+    AclStatus aclStatus = fileSystem.getAclStatus(new Path(src));
+    // Delete file
     fileSystem.delete(new Path(src), true);
-    //create file
+    // Create file
     fileSystem.create(new Path(src), true);
-    //set metadata
+    // Set metadata
     fileSystem.setOwner(new Path(src), fileStatus.getOwner(), fileStatus.getGroup());
     fileSystem.setPermission(new Path(src), fileStatus.getPermission());
     fileSystem.setReplication(new Path(src), fileStatus.getReplication());
     fileSystem.setStoragePolicy(new Path(src), "Cold");
     // fileSystem.setTimes(new Path(src), fileStatus.getAccessTime(),
     //     fileSystem.getFileStatus(new Path(src)).getModificationTime());
+    fileSystem.setAcl(new Path(src), aclStatus.getEntries());
     return true;
   }
 

--- a/smart-hadoop-support/smart-hadoop-2.7/src/main/java/org/smartdata/hdfs/CompatibilityHelper27.java
+++ b/smart-hadoop-support/smart-hadoop-2.7/src/main/java/org/smartdata/hdfs/CompatibilityHelper27.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.StorageType;
-import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.SmartInputStreamFactory;
@@ -174,7 +173,7 @@ public class CompatibilityHelper27 implements CompatibilityHelper {
     // Delete file and create file
     // Save the metadata
     HdfsFileStatus fileStatus = client.getFileInfo(src);
-    AclStatus aclStatus = client.getAclStatus(src);
+    // AclStatus aclStatus = client.getAclStatus(src);
     // Delete file
     client.delete(src, true);
     // Create file
@@ -186,7 +185,7 @@ public class CompatibilityHelper27 implements CompatibilityHelper {
     client.setStoragePolicy(src, "Cold");
     client.setTimes(src, fileStatus.getAccessTime(),
         client.getFileInfo(src).getModificationTime());
-    client.setAcl(src, aclStatus.getEntries());
+    // client.setAcl(src, aclStatus.getEntries());
     return true;
   }
 
@@ -196,7 +195,7 @@ public class CompatibilityHelper27 implements CompatibilityHelper {
     // Delete file and create file
     // Save the metadata
     FileStatus fileStatus = fileSystem.getFileStatus(new Path(src));
-    AclStatus aclStatus = fileSystem.getAclStatus(new Path(src));
+    // AclStatus aclStatus = fileSystem.getAclStatus(new Path(src));
     // Delete file
     fileSystem.delete(new Path(src), true);
     // Create file
@@ -208,7 +207,7 @@ public class CompatibilityHelper27 implements CompatibilityHelper {
     fileSystem.setStoragePolicy(new Path(src), "Cold");
     // fileSystem.setTimes(new Path(src), fileStatus.getAccessTime(),
     //     fileSystem.getFileStatus(new Path(src)).getModificationTime());
-    fileSystem.setAcl(new Path(src), aclStatus.getEntries());
+    // fileSystem.setAcl(new Path(src), aclStatus.getEntries());
     return true;
   }
 

--- a/smart-hadoop-support/smart-hadoop-cdh-2.6/src/main/java/org/smartdata/hdfs/CompatibilityHelper26.java
+++ b/smart-hadoop-support/smart-hadoop-cdh-2.6/src/main/java/org/smartdata/hdfs/CompatibilityHelper26.java
@@ -162,38 +162,43 @@ public class CompatibilityHelper26 implements CompatibilityHelper {
 
   @Override
   public boolean setLen2Zero(DFSClient client, String src) throws IOException {
-    //Delete file and create file
-    //save the metadata
+    // Delete file and create file
+    // Save the metadata
     HdfsFileStatus fileStatus = client.getFileInfo(src);
-    //delete file
+    AclStatus aclStatus = client.getAclStatus(src);
+    // Delete file
     client.delete(src, true);
-    //create file
+    // Create file
     client.create(src, true);
-    //set metadata
+    // Set metadata
     client.setOwner(src, fileStatus.getOwner(), fileStatus.getGroup());
     client.setPermission(src, fileStatus.getPermission());
     client.setReplication(src, fileStatus.getReplication());
     client.setStoragePolicy(src, "Cold");
-    // client.setTimes(src, fileStatus.getAccessTime(), client.getFileInfo(src).getModificationTime());
+    // client.setTimes(src, fileStatus.getAccessTime(),
+    //     client.getFileInfo(src).getModificationTime());
+    client.setAcl(src, aclStatus.getEntries());
     return true;
   }
 
   @Override
   public boolean setLen2Zero(DistributedFileSystem fileSystem, String src) throws IOException {
-    //Delete file and create file
-    //save the metadata
+    // Delete file and create file
+    // Save the metadata
     FileStatus fileStatus = fileSystem.getFileStatus(new Path(src));
-    //delete file
+    AclStatus aclStatus = fileSystem.getAclStatus(new Path(src));
+    // Delete file
     fileSystem.delete(new Path(src), true);
-    //create file
+    // Create file
     fileSystem.create(new Path(src), true);
-    //set metadata
+    // Set metadata
     fileSystem.setOwner(new Path(src), fileStatus.getOwner(), fileStatus.getGroup());
     fileSystem.setPermission(new Path(src), fileStatus.getPermission());
     fileSystem.setReplication(new Path(src), fileStatus.getReplication());
     fileSystem.setStoragePolicy(new Path(src), "Cold");
     // fileSystem.setTimes(new Path(src), fileStatus.getAccessTime(),
     //     fileSystem.getFileStatus(new Path(src)).getModificationTime());
+    fileSystem.setAcl(new Path(src), aclStatus.getEntries());
     return true;
   }
 

--- a/smart-hadoop-support/smart-hadoop-cdh-2.6/src/main/java/org/smartdata/hdfs/CompatibilityHelper26.java
+++ b/smart-hadoop-support/smart-hadoop-cdh-2.6/src/main/java/org/smartdata/hdfs/CompatibilityHelper26.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdfs.protocol.datatransfer.Sender;
 import org.apache.hadoop.hdfs.protocol.proto.InotifyProtos;
 import org.apache.hadoop.hdfs.security.token.block.BlockTokenIdentifier;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
-import org.apache.hadoop.hdfs.server.protocol.DatanodeStorageReport;
 import org.apache.hadoop.hdfs.server.protocol.StorageReport;
 import org.apache.hadoop.security.token.Token;
 
@@ -165,7 +164,7 @@ public class CompatibilityHelper26 implements CompatibilityHelper {
     // Delete file and create file
     // Save the metadata
     HdfsFileStatus fileStatus = client.getFileInfo(src);
-    AclStatus aclStatus = client.getAclStatus(src);
+    // AclStatus aclStatus = client.getAclStatus(src);
     // Delete file
     client.delete(src, true);
     // Create file
@@ -177,7 +176,7 @@ public class CompatibilityHelper26 implements CompatibilityHelper {
     client.setStoragePolicy(src, "Cold");
     // client.setTimes(src, fileStatus.getAccessTime(),
     //     client.getFileInfo(src).getModificationTime());
-    client.setAcl(src, aclStatus.getEntries());
+    // client.setAcl(src, aclStatus.getEntries());
     return true;
   }
 
@@ -186,7 +185,7 @@ public class CompatibilityHelper26 implements CompatibilityHelper {
     // Delete file and create file
     // Save the metadata
     FileStatus fileStatus = fileSystem.getFileStatus(new Path(src));
-    AclStatus aclStatus = fileSystem.getAclStatus(new Path(src));
+    // AclStatus aclStatus = fileSystem.getAclStatus(new Path(src));
     // Delete file
     fileSystem.delete(new Path(src), true);
     // Create file
@@ -198,7 +197,7 @@ public class CompatibilityHelper26 implements CompatibilityHelper {
     fileSystem.setStoragePolicy(new Path(src), "Cold");
     // fileSystem.setTimes(new Path(src), fileStatus.getAccessTime(),
     //     fileSystem.getFileStatus(new Path(src)).getModificationTime());
-    fileSystem.setAcl(new Path(src), aclStatus.getEntries());
+    // fileSystem.setAcl(new Path(src), aclStatus.getEntries());
     return true;
   }
 

--- a/smart-hadoop-support/smart-hadoop-cdh-2.6/src/main/java/org/smartdata/hdfs/CompatibilityHelper26.java
+++ b/smart-hadoop-support/smart-hadoop-cdh-2.6/src/main/java/org/smartdata/hdfs/CompatibilityHelper26.java
@@ -165,7 +165,6 @@ public class CompatibilityHelper26 implements CompatibilityHelper {
     //Delete file and create file
     //save the metadata
     HdfsFileStatus fileStatus = client.getFileInfo(src);
-
     //delete file
     client.delete(src, true);
     //create file
@@ -174,10 +173,8 @@ public class CompatibilityHelper26 implements CompatibilityHelper {
     client.setOwner(src, fileStatus.getOwner(), fileStatus.getGroup());
     client.setPermission(src, fileStatus.getPermission());
     client.setReplication(src, fileStatus.getReplication());
-    // TODO set Storagepolicy
-    client.setStoragePolicy(src, "Hot");
+    client.setStoragePolicy(src, "Cold");
     // client.setTimes(src, fileStatus.getAccessTime(), client.getFileInfo(src).getModificationTime());
-
     return true;
   }
 
@@ -186,7 +183,6 @@ public class CompatibilityHelper26 implements CompatibilityHelper {
     //Delete file and create file
     //save the metadata
     FileStatus fileStatus = fileSystem.getFileStatus(new Path(src));
-
     //delete file
     fileSystem.delete(new Path(src), true);
     //create file
@@ -195,11 +191,9 @@ public class CompatibilityHelper26 implements CompatibilityHelper {
     fileSystem.setOwner(new Path(src), fileStatus.getOwner(), fileStatus.getGroup());
     fileSystem.setPermission(new Path(src), fileStatus.getPermission());
     fileSystem.setReplication(new Path(src), fileStatus.getReplication());
-    // TODO set Storagepolicy
-    fileSystem.setStoragePolicy(new Path(src), "Hot");
+    fileSystem.setStoragePolicy(new Path(src), "Cold");
     // fileSystem.setTimes(new Path(src), fileStatus.getAccessTime(),
     //     fileSystem.getFileStatus(new Path(src)).getModificationTime());
-
     return true;
   }
 


### PR DESCRIPTION
* Switch Truncate0 from truncate op to delete and create (just like CDH). Truncate0 action won't trigger length change in file table on hadoop-2.7. This is because the truncate inotify is not added until hadoop-2.8. 
* Code style.
* Add acl related code to setLen2Zero.