### PR TITLE
Refine test_stress_sync script

### DIFF
--- a/supports/integration-test/test_S3_1MB.py
+++ b/supports/integration-test/test_S3_1MB.py
@@ -19,8 +19,7 @@ class Test_S3_1MB(unittest.TestCase):
         # create 1K random files in random directory
         for i in range(max_number):
             file_paths.append(
-                create_random_file_parallel_return_file_name(FILE_SIZE,
-                                                             source_dir))
+                create_random_file_parallel(FILE_SIZE, source_dir)[0])
         time.sleep(1)
 
         # submit action

--- a/supports/integration-test/test_small_file.py
+++ b/supports/integration-test/test_small_file.py
@@ -15,7 +15,7 @@ class TestSmallFile(unittest.TestCase):
         # create 500 random files in random directory
         for i in range(max_number):
             file_paths.append(create_random_file_parallel(FILE_SIZE,
-                                                          source_dir))
+                                                          source_dir)[0])
         time.sleep(2)
         # compact rule
         rule_str = "file : path matches " + \

--- a/supports/integration-test/test_small_file.py
+++ b/supports/integration-test/test_small_file.py
@@ -36,7 +36,7 @@ class TestSmallFile(unittest.TestCase):
         delete_rule(rid)
         # delete all random files
         for i in range(max_number):
-            cids.append(delete_file(file_path[i]))
+            cids.append(delete_file(file_paths[i]))
         wait_for_cmdlets(cids)
 
 

--- a/supports/integration-test/test_stress_sync_10MB.py
+++ b/supports/integration-test/test_stress_sync_10MB.py
@@ -5,7 +5,7 @@ from util import *
 
 # 10MB
 FILE_SIZE = 10 * 1024 * 1024
-DEST_DIR = "hdfs://datanode3:9000/dest"
+DEST_DIR = "hdfs://localhost:9000/dest"
 
 
 class TestStressDR(unittest.TestCase):

--- a/supports/integration-test/test_stress_sync_10MB.py
+++ b/supports/integration-test/test_stress_sync_10MB.py
@@ -21,7 +21,7 @@ class TestStressDR(unittest.TestCase):
         # create 10K random files in random directory
         for i in range(max_number):
             file_paths.append(create_random_file_parallel(FILE_SIZE,
-                                                          source_dir))
+                                                          source_dir)[0])
         time.sleep(1)
         rule_str = "file : every 1s | path matches " + \
             "\"" + source_dir + "*\" | sync -dest " + DEST_DIR
@@ -41,7 +41,7 @@ class TestStressDR(unittest.TestCase):
         delete_rule(rid)
         # delete all random files
         for i in range(max_number):
-            cids.append(delete_file(file_path[i]))
+            cids.append(delete_file(file_paths[i]))
         wait_for_cmdlets(cids)
 
     def test_sync_rule_100000(self):
@@ -56,7 +56,7 @@ class TestStressDR(unittest.TestCase):
         # create 10K random files in random directory
         for i in range(max_number):
             file_paths.append(create_random_file_parallel(FILE_SIZE,
-                                                          source_dir))
+                                                          source_dir)[0])
         time.sleep(1)
         rule_str = "file : every 1s | path matches " + \
             "\"" + source_dir + "*\" | sync -dest " + DEST_DIR
@@ -76,7 +76,7 @@ class TestStressDR(unittest.TestCase):
         delete_rule(rid)
         # delete all random files
         for i in range(max_number):
-            cids.append(delete_file(file_path[i]))
+            cids.append(delete_file(file_paths[i]))
         wait_for_cmdlets(cids)
 
 

--- a/supports/integration-test/test_stress_sync_1MB.py
+++ b/supports/integration-test/test_stress_sync_1MB.py
@@ -5,7 +5,7 @@ from util import *
 
 # 1MB
 FILE_SIZE = 1024 * 1024
-DEST_DIR = "hdfs://datanode3:9000/dest"
+DEST_DIR = "hdfs://localhost:9000/dest"
 
 
 class TestStressDR(unittest.TestCase):

--- a/supports/integration-test/test_stress_sync_1MB.py
+++ b/supports/integration-test/test_stress_sync_1MB.py
@@ -41,7 +41,7 @@ class TestStressDR(unittest.TestCase):
         delete_rule(rid)
         # delete all random files
         for i in range(max_number):
-            cids.append(delete_file(file_path[i]))
+            cids.append(delete_file(file_paths[i]))
         wait_for_cmdlets(cids)
 
     def test_sync_rule_100000(self):
@@ -76,7 +76,7 @@ class TestStressDR(unittest.TestCase):
         delete_rule(rid)
         # delete all random files
         for i in range(max_number):
-            cids.append(delete_file(file_path[i]))
+            cids.append(delete_file(file_paths[i]))
         wait_for_cmdlets(cids)
 
 

--- a/supports/integration-test/test_stress_sync_1MB.py
+++ b/supports/integration-test/test_stress_sync_1MB.py
@@ -21,7 +21,7 @@ class TestStressDR(unittest.TestCase):
         # create 10K random files in random directory
         for i in range(max_number):
             file_paths.append(create_random_file_parallel(FILE_SIZE,
-                                                          source_dir))
+                                                          source_dir)[0])
         time.sleep(1)
         rule_str = "file : every 1s | path matches " + \
             "\"" + source_dir + "*\" | sync -dest " + DEST_DIR
@@ -56,7 +56,7 @@ class TestStressDR(unittest.TestCase):
         # create 10K random files in random directory
         for i in range(max_number):
             file_paths.append(create_random_file_parallel(FILE_SIZE,
-                                                          source_dir))
+                                                          source_dir)[0])
         time.sleep(1)
         rule_str = "file : every 1s | path matches " + \
             "\"" + source_dir + "*\" | sync -dest " + DEST_DIR

--- a/supports/integration-test/util.py
+++ b/supports/integration-test/util.py
@@ -227,18 +227,6 @@ def create_random_file_parallel(length=1024, dest_path=TEST_DIR):
     return file_path, submit_cmdlet(cmdlet_str)
 
 
-def create_random_file_parallel_return_file_name(dest_path, length=1024):
-    """
-    create a random file in /dest_path/
-    """
-    file_name = random_string()
-    file_path = dest_path + file_name
-    cmdlet_str = "write -file " + \
-                 file_path + " -length " + str(length)
-    submit_cmdlet(cmdlet_str)
-    return file_name
-
-
 def copy_file_to_S3(file_path, dest_path):
     """
     move file to S3


### PR DESCRIPTION
* Fix a bug in test_stress_sync caused by file_paths. 
* Fix a bug in test_small_file caused by file_paths.
* Set DEST_DIR=localhost.
* Remove create_random_file_parallel_return_file_name in util.py.