### PR TITLE
Tune Performance on large namespace

### DIFF
--- a/conf/smart-default.xml
+++ b/conf/smart-default.xml
@@ -115,6 +115,22 @@
   </property>
 
   <property>
+    <name>smart.cmdlet.cache.batch</name>
+    <value>600</value>
+    <description>
+      Maximum batch size of cmdlet batch insert.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.copy.scheduler.base.sync.batch</name>
+    <value>500</value>
+    <description>
+      Maximum batch size of copyscheduer base sync batch insert.
+    </description>
+  </property>
+
+  <property>
     <name>pd.client.port</name>
     <value>7060</value>
     <description>Pd port in client-url option</description>

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
@@ -94,6 +94,16 @@ public class SmartConfKeys {
       "smart.cmdlet.hist.max.record.lifetime";
   public static final String SMART_CMDLET_HIST_MAX_RECORD_LIFETIME_DEFAULT =
       "30day";
+  public static final String SMART_CMDLET_CACHE_BATCH =
+      "smart.cmdlet.cache.batch";
+  public static final int SMART_CMDLET_CACHE_BATCH_DEFAULT =
+      600;
+
+  // Schedulers
+  public static final String SMART_COPY_SCHEDULER_BASE_SYNC_BATCH =
+      "smart.copy.scheduler.base.sync.batch";
+  public static final int SMART_COPY_SCHEDULER_BASE_SYNC_BATCH_DEFAULT =
+      500;
 
   // Action
   public static final String SMART_ACTION_MOVE_THROTTLE_MB_KEY = "smart.action.move.throttle.mb";

--- a/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
@@ -84,8 +84,8 @@ public class CmdletManager extends AbstractService {
   private MetaStore metaStore;
   private AtomicLong maxActionId;
   private AtomicLong maxCmdletId;
-  // cache sync threshold, default 400
-  private int cacheCmdTh = 400;
+  // cache sync threshold, default 500
+  private int cacheCmdTh = 600;
 
   private int maxNumPendingCmdlets;
   private List<Long> pendingCmdlet;
@@ -375,15 +375,17 @@ public class CmdletManager extends AbstractService {
   }
 
   private synchronized void batchSyncCmdAction() throws IOException {
-    LOG.debug("Number of cached cmds {}", cacheCmd.size());
+    LOG.info("Number of cached cmds {}", cacheCmd.size());
     List<CmdletInfo> cmdletInfos = new ArrayList<>();
     List<ActionInfo> actionInfos = new ArrayList<>();
     for (Long cid : cacheCmd.keySet()) {
       cmdletInfos.add(cacheCmd.get(cid));
+      if (cmdletInfos.size() >= cacheCmdTh) break;
       for (Long aid : cacheCmd.get(cid).getAids()) {
         actionInfos.add(idToActions.get(aid));
       }
     }
+    LOG.info("Number of cmds {} to submit", cacheCmd.size());
     try {
       metaStore.insertCmdlets(
           cmdletInfos.toArray(new CmdletInfo[cmdletInfos.size()]));

--- a/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
@@ -123,8 +123,12 @@ public class CmdletManager extends AbstractService {
     this.purgeTask = new CmdletPurgeTask(context.getConf());
     this.dispatcher = new CmdletDispatcher(context, this, scheduledCmdlet,
         idToLaunchCmdlet, runningCmdlets, schedulers);
-    maxNumPendingCmdlets = context.getConf().getInt(SmartConfKeys.SMART_CMDLET_MAX_NUM_PENDING_KEY,
+    maxNumPendingCmdlets = context.getConf()
+        .getInt(SmartConfKeys.SMART_CMDLET_MAX_NUM_PENDING_KEY,
         SmartConfKeys.SMART_CMDLET_MAX_NUM_PENDING_DEFAULT);
+    cacheCmdTh = context.getConf()
+        .getInt(SmartConfKeys.SMART_CMDLET_CACHE_BATCH,
+        SmartConfKeys.SMART_CMDLET_CACHE_BATCH_DEFAULT);
   }
 
   @VisibleForTesting
@@ -380,7 +384,9 @@ public class CmdletManager extends AbstractService {
     List<ActionInfo> actionInfos = new ArrayList<>();
     for (Long cid : cacheCmd.keySet()) {
       cmdletInfos.add(cacheCmd.get(cid));
-      if (cmdletInfos.size() >= cacheCmdTh) break;
+      if (cmdletInfos.size() >= cacheCmdTh){
+        break;
+      }
       for (Long aid : cacheCmd.get(cid).getAids()) {
         actionInfos.add(idToActions.get(aid));
       }

--- a/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
@@ -379,7 +379,9 @@ public class CmdletManager extends AbstractService {
   }
 
   private synchronized void batchSyncCmdAction() throws IOException {
-    LOG.info("Number of cached cmds {}", cacheCmd.size());
+    if (cacheCmd.size() != 0) {
+      LOG.info("Number of cached cmds {}", cacheCmd.size());
+    }
     List<CmdletInfo> cmdletInfos = new ArrayList<>();
     List<ActionInfo> actionInfos = new ArrayList<>();
     for (Long cid : cacheCmd.keySet()) {
@@ -391,7 +393,9 @@ public class CmdletManager extends AbstractService {
         actionInfos.add(idToActions.get(aid));
       }
     }
-    LOG.info("Number of cmds {} to submit", cacheCmd.size());
+    if (cmdletInfos.size() != 0) {
+      LOG.info("Number of cmds {} to submit", cmdletInfos.size());
+    }
     try {
       metaStore.insertCmdlets(
           cmdletInfos.toArray(new CmdletInfo[cmdletInfos.size()]));
@@ -1051,15 +1055,17 @@ public class CmdletManager extends AbstractService {
   }
 
   private class ScheduleTask implements Runnable {
+    private int round;
     public ScheduleTask() {
+      round = 0;
     }
 
     @Override
     public void run() {
       try {
         int nScheduled;
+        batchSyncCmdAction();
         do {
-          batchSyncCmdAction();
           nScheduled = scheduleCmdlet();
           totalScheduled += nScheduled;
         } while (nScheduled != 0);

--- a/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
@@ -362,6 +362,7 @@ public class CmdletManager extends AbstractService {
   private void syncCmdAction(CmdletInfo cmdletInfo,
       List<ActionInfo> actionInfos) throws IOException {
     lockMovefileActionFiles(actionInfos);
+    LOG.info("Cache cmd {}", cmdletInfo);
     for (ActionInfo actionInfo : actionInfos) {
       idToActions.put(actionInfo.getActionId(), actionInfo);
     }
@@ -376,10 +377,12 @@ public class CmdletManager extends AbstractService {
   }
 
   private synchronized void batchSyncCmdAction() throws IOException {
-    List<CmdletInfo> cmdletInfos = (List<CmdletInfo>) cacheCmd.values();
+    LOG.info("Number of cached cmds {}", cacheCmd.size());
+    List<CmdletInfo> cmdletInfos = new ArrayList<>();
     List<ActionInfo> actionInfos = new ArrayList<>();
-    for (CmdletInfo cmdletInfo : cmdletInfos) {
-      for (Long aid : cmdletInfo.getAids()) {
+    for (Long cid : cacheCmd.keySet()) {
+      cmdletInfos.add(cacheCmd.get(cid));
+      for (Long aid : cacheCmd.get(cid).getAids()) {
         actionInfos.add(idToActions.get(aid));
       }
     }

--- a/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
@@ -379,9 +379,10 @@ public class CmdletManager extends AbstractService {
   }
 
   private synchronized void batchSyncCmdAction() throws IOException {
-    if (cacheCmd.size() != 0) {
-      LOG.info("Number of cached cmds {}", cacheCmd.size());
+    if (cacheCmd.size() == 0) {
+      return;
     }
+    LOG.debug("Number of cached cmds {}", cacheCmd.size());
     List<CmdletInfo> cmdletInfos = new ArrayList<>();
     List<ActionInfo> actionInfos = new ArrayList<>();
     for (Long cid : cacheCmd.keySet()) {
@@ -393,9 +394,10 @@ public class CmdletManager extends AbstractService {
         actionInfos.add(idToActions.get(aid));
       }
     }
-    if (cmdletInfos.size() != 0) {
-      LOG.info("Number of cmds {} to submit", cmdletInfos.size());
+    if (cmdletInfos.size() == 0) {
+      return;
     }
+    LOG.debug("Number of cmds {} to submit", cmdletInfos.size());
     try {
       metaStore.insertCmdlets(
           cmdletInfos.toArray(new CmdletInfo[cmdletInfos.size()]));

--- a/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
@@ -84,8 +84,8 @@ public class CmdletManager extends AbstractService {
   private MetaStore metaStore;
   private AtomicLong maxActionId;
   private AtomicLong maxCmdletId;
-  // cache sync threshold, default 100
-  private int cacheCmdTh = 100;
+  // cache sync threshold, default 400
+  private int cacheCmdTh = 400;
 
   private int maxNumPendingCmdlets;
   private List<Long> pendingCmdlet;
@@ -371,9 +371,6 @@ public class CmdletManager extends AbstractService {
     cacheCmd.put(cmdletInfo.getCid(), cmdletInfo);
     synchronized (pendingCmdlet) {
       pendingCmdlet.add(cmdletInfo.getCid());
-    }
-    if (cacheCmd.size() >= cacheCmdTh) {
-      batchSyncCmdAction();
     }
   }
 

--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletDispatcher.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletDispatcher.java
@@ -218,7 +218,7 @@ public class CmdletDispatcher {
     @Override
     public void run() {
       long curr = System.currentTimeMillis();
-      if (curr - lastInfo >= 5000) {
+      if (curr - lastInfo >= 2000) {
         if (!(statDispatched == 0 && statRound == statNoMoreCmdlet)) {
           LOG.info(
               "timeInterval={} statRound={} statFail={} statDispatched={} "

--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletDispatcher.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletDispatcher.java
@@ -218,7 +218,7 @@ public class CmdletDispatcher {
     @Override
     public void run() {
       long curr = System.currentTimeMillis();
-      if (curr - lastInfo >= 2000) {
+      if (curr - lastInfo >= 3000) {
         if (!(statDispatched == 0 && statRound == statNoMoreCmdlet)) {
           LOG.info(
               "timeInterval={} statRound={} statFail={} statDispatched={} "

--- a/smart-engine/src/main/java/org/smartdata/server/engine/rule/RuleExecutor.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/rule/RuleExecutor.java
@@ -305,7 +305,7 @@ public class RuleExecutor implements Runnable {
                 + "ms, SubmitTime = "
                 + (endProcessTime - endCheckTime)
                 + "ms, fileNum = "
-                + files.size()
+                + numCmdSubmitted
                 + ".");
       }
 

--- a/smart-engine/src/main/java/org/smartdata/server/engine/rule/RuleExecutor.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/rule/RuleExecutor.java
@@ -294,7 +294,7 @@ public class RuleExecutor implements Runnable {
       // System.out.println(this + " -> " + System.currentTimeMillis());
       long endProcessTime = System.currentTimeMillis();
 
-      if (endProcessTime - startCheckTime > 3000 || LOG.isDebugEnabled()) {
+      if (endProcessTime - startCheckTime > 2000 || LOG.isDebugEnabled()) {
         LOG.warn(
             "Rule "
                 + ctx.getRuleId()
@@ -304,7 +304,9 @@ public class RuleExecutor implements Runnable {
                 + (endCheckTime - startCheckTime)
                 + "ms, SubmitTime = "
                 + (endProcessTime - endCheckTime)
-                + "ms.");
+                + "ms, fileNum = "
+                + files.size()
+                + ".");
       }
 
     } catch (IOException e) {

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smartdata.SmartContext;
 import org.smartdata.action.SyncAction;
+import org.smartdata.conf.SmartConfKeys;
 import org.smartdata.hdfs.action.HdfsAction;
 import org.smartdata.metastore.MetaStore;
 import org.smartdata.metastore.MetaStoreException;
@@ -103,6 +104,9 @@ public class CopyScheduler extends ActionSchedulerService {
     this.executorService = Executors.newSingleThreadScheduledExecutor();
     try {
       conf = getContext().getConf();
+      cacheSyncTh = conf.getInt(SmartConfKeys
+          .SMART_COPY_SCHEDULER_BASE_SYNC_BATCH,
+          SmartConfKeys.SMART_COPY_SCHEDULER_BASE_SYNC_BATCH_DEFAULT);
     } catch (NullPointerException e) {
       // SmartContext is empty
       conf = new Configuration();

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -82,7 +82,7 @@ public class CopyScheduler extends ActionSchedulerService {
   // Check interval of executorService
   private long checkInterval = 150;
   // Base sync batch insert size
-  private int batchSize = 300;
+  private int batchSize = 500;
   // Cache of the file_diff
   private Map<Long, FileDiff> fileDiffCache;
   // cache sync threshold, default 100
@@ -321,7 +321,9 @@ public class CopyScheduler extends ActionSchedulerService {
   private void baseSync(String srcDir,
       String destDir) throws MetaStoreException {
     List<FileInfo> srcFiles = metaStore.getFilesByPrefix(srcDir);
-    LOG.debug("Directory Base Sync {} files", srcFiles.size());
+    if (srcFiles.size() > 0) {
+      LOG.info("Directory Base Sync {} files", srcFiles.size());
+    }
     // <file name, fileInfo>
     Map<String, FileInfo> srcFileSet = new HashMap<>();
     for (FileInfo fileInfo : srcFiles) {

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -85,8 +85,8 @@ public class CopyScheduler extends ActionSchedulerService {
   private int batchSize = 300;
   // Cache of the file_diff
   private Map<Long, FileDiff> fileDiffCache;
-  // cache sync threshold, default 50
-  private int cacheSyncTh = 50;
+  // cache sync threshold, default 100
+  private int cacheSyncTh = 100;
   // record the file_diff whether being changed
   private Map<Long, Boolean> fileDiffCacheChanged;
 
@@ -548,6 +548,11 @@ public class CopyScheduler extends ActionSchedulerService {
 
   @Override
   public void stop() throws IOException {
+    try {
+      batchDirectSync();
+    } catch (MetaStoreException e) {
+      throw new IOException(e);
+    }
     executorService.shutdown();
   }
 

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -904,6 +904,9 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
 
   public void insertCmdlets(CmdletInfo[] commands)
       throws MetaStoreException {
+    if (commands.length == 0) {
+      return;
+    }
     try {
       cmdletDao.insert(commands);
     } catch (Exception e) {

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -902,7 +902,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
 
-  public synchronized void insertCmdlets(CmdletInfo[] commands)
+  public void insertCmdlets(CmdletInfo[] commands)
       throws MetaStoreException {
     try {
       cmdletDao.insert(commands);
@@ -911,7 +911,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
     }
   }
 
-  public synchronized void insertCmdlet(CmdletInfo command)
+  public void insertCmdlet(CmdletInfo command)
       throws MetaStoreException {
     try {
       // Update if exists
@@ -1032,7 +1032,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
     }
   }
 
-  public synchronized void insertActions(ActionInfo[] actionInfos)
+  public void insertActions(ActionInfo[] actionInfos)
       throws MetaStoreException {
     try {
       actionDao.insert(actionInfos);
@@ -1041,7 +1041,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
     }
   }
 
-  public synchronized void insertAction(ActionInfo actionInfo)
+  public void insertAction(ActionInfo actionInfo)
       throws MetaStoreException {
     LOG.debug("Insert Action ID {}", actionInfo.getActionId());
     try {
@@ -1115,7 +1115,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
     }
   }
 
-  public synchronized void updateActions(ActionInfo[] actionInfos)
+  public void updateActions(ActionInfo[] actionInfos)
       throws MetaStoreException {
     if (actionInfos == null || actionInfos.length == 0) {
       return;

--- a/smart-server/src/test/java/org/smartdata/server/engine/TestCmdletManager.java
+++ b/smart-server/src/test/java/org/smartdata/server/engine/TestCmdletManager.java
@@ -173,11 +173,12 @@ public class TestCmdletManager extends MiniSmartClusterHarness {
 
     cmdletManager.start();
     cmdletManager.submitCmdlet("hello");
-    verify(metaStore, times(1)).insertCmdlet(any(CmdletInfo.class));
-    verify(metaStore, times(1)).insertActions(any(ActionInfo[].class));
 
+    Thread.sleep(500);
     Assert.assertEquals(1, cmdletManager.getCmdletsSizeInCache());
-    Thread.sleep(1000);
+    verify(metaStore, times(1)).insertCmdlets(any(CmdletInfo[].class));
+    verify(metaStore, times(1)).insertActions(any(ActionInfo[].class));
+    Thread.sleep(500);
 
     long actionStartTime = System.currentTimeMillis();
     cmdletManager.updateStatus(new ActionStarted(actionId, actionStartTime));


### PR DESCRIPTION
* Batch support in submitCmd. Now cmdletmanager will cache some cmdlets.
* Remove unnecessary pessimistic locks in action status report.
* Remove unnecessary pessimistic locks in insertCmdlet and insertAction.