### PR TITLE
Solve #1732, fix YARN and MapReduce fails caused by getFileState

### DIFF
--- a/smart-client/src/main/java/org/smartdata/client/SmartClient.java
+++ b/smart-client/src/main/java/org/smartdata/client/SmartClient.java
@@ -102,7 +102,8 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
     try {
       return server.getFileState(filePath);
     } catch (ConnectException e) {
-      // SSM is not started
+      // client cannot connect to server
+      // don't report access event for this file this time
       singleIgnoreList.put(filePath, 0);
       return new NormalFileState(filePath);
     }
@@ -110,6 +111,7 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
 
   private boolean shouldIgnore(String path) {
     if (singleIgnoreList.containsKey(path)) {
+      // this report should be ignored
       singleIgnoreList.remove(path);
       return true;
     }

--- a/smart-client/src/main/java/org/smartdata/client/SmartClient.java
+++ b/smart-client/src/main/java/org/smartdata/client/SmartClient.java
@@ -24,11 +24,13 @@ import org.apache.hadoop.ipc.RPC;
 import org.smartdata.conf.SmartConfKeys;
 import org.smartdata.metrics.FileAccessEvent;
 import org.smartdata.model.FileState;
+import org.smartdata.model.NormalFileState;
 import org.smartdata.protocol.SmartClientProtocol;
 import org.smartdata.protocol.protobuffer.ClientProtocolClientSideTranslator;
 import org.smartdata.protocol.protobuffer.ClientProtocolProtoBuffer;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -92,7 +94,13 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
 
   @Override
   public FileState getFileState(String filePath) throws IOException {
-    return server.getFileState(filePath);
+    checkOpen();
+    try {
+      return server.getFileState(filePath);
+    } catch (ConnectException e) {
+      // SSM is not started
+      return new NormalFileState(filePath);
+    }
   }
 
   private boolean shouldIgnore(String path) {

--- a/smart-client/src/main/java/org/smartdata/client/SmartClient.java
+++ b/smart-client/src/main/java/org/smartdata/client/SmartClient.java
@@ -34,9 +34,9 @@ import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SmartClient implements java.io.Closeable, SmartClientProtocol {
   private static final long VERSION = 1;
@@ -81,7 +81,7 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
     Collection<String> dirs = conf.getTrimmedStringCollection(
         SmartConfKeys.SMART_IGNORE_DIRS_KEY);
     ignoreAccessEventDirs = new ArrayList<>();
-    singleIgnoreList = new HashMap<>(1000);
+    singleIgnoreList = new ConcurrentHashMap<>(200);
     for (String s : dirs) {
       ignoreAccessEventDirs.add(s + (s.endsWith("/") ? "" : "/"));
     }


### PR DESCRIPTION
* Ensure that YARN and MapReduce work well even if SSM is shutdown. 
* Suppress unnecessary error logs caused by reportFileAccessEvent.