### PR TITLE
Solve #1684, optimize file_diff table access

### DIFF
--- a/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
@@ -116,6 +116,10 @@ public class SmartConfKeys {
       "smart.copy.scheduler.base.sync.batch";
   public static final int SMART_COPY_SCHEDULER_BASE_SYNC_BATCH_DEFAULT =
       500;
+  public static final String SMART_COPY_SCHEDULER_CHECK_INTERVAL =
+      "smart.copy.scheduler.check.interval";
+  public static final int SMART_COPY_SCHEDULER_CHECK_INTERVAL_DEFAULT =
+      500;
 
   // Dispatcher
   public static final String SMART_CMDLET_DISPATCHER_LOG_DISP_RESULT_KEY =

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -293,15 +293,15 @@ public class CopyScheduler extends ActionSchedulerService {
   }
 
   private void batchDirectSync() throws MetaStoreException {
-    int index = 0;
     // Use 90% of check interval to batchSync
     if (baseSyncQueue.size() == 0) {
-      LOG.debug("Base Sync size = 0!");
       return;
     }
+    LOG.debug("Base Sync size = {}", baseSyncQueue.size());
     List<FileDiff> batchFileDiffs = new ArrayList<>();
     List<String> removed = new ArrayList<>();
     FileDiff fileDiff;
+    int index = 0;
     for (Iterator<Map.Entry<String, String>> it =
         baseSyncQueue.entrySet().iterator(); it.hasNext(); ) {
       if (index >= batchSize) {
@@ -425,11 +425,13 @@ public class CopyScheduler extends ActionSchedulerService {
     }
     // Mark all related diff in metastore as Merged
     List<FileDiff> fileDiffs = metaStore.getFileDiffsByFileName(src);
+    List<Long> dids = new ArrayList<>();
     for (FileDiff fileDiff : fileDiffs) {
       if (fileDiff.getState() == FileDiffState.PENDING) {
-        metaStore.updateFileDiff(fileDiff.getDiffId(), FileDiffState.MERGED);
+        dids.add(fileDiff.getDiffId());
       }
     }
+    metaStore.batchUpdateFileDiff(dids, FileDiffState.MERGED);
     // Unlock this file
     fileLock.remove(src);
     // Generate a new file diff
@@ -545,7 +547,6 @@ public class CopyScheduler extends ActionSchedulerService {
   }
 
   private void pushCacheToDB() throws MetaStoreException {
-    LOG.debug("Push FileFiff From cache Into FileDiff");
     List<FileDiff> updatedFileDiffs = new ArrayList<>();
     List<Long> needDel = new ArrayList<>();
     FileDiff fileDiff;
@@ -562,7 +563,10 @@ public class CopyScheduler extends ActionSchedulerService {
       }
     }
     // Push cache to metastore
-    metaStore.updateFileDiff(updatedFileDiffs);
+    if (updatedFileDiffs.size() != 0) {
+      LOG.debug("Push FileDiff from cache to metastore");
+      metaStore.updateFileDiff(updatedFileDiffs);
+    }
     // Remove file diffs in cache and file lock
     for (long did : needDel) {
       deleteDiffInCache(did);
@@ -884,14 +888,17 @@ public class CopyScheduler extends ActionSchedulerService {
       }
 
       void markAllDiffs() throws MetaStoreException {
+        List<Long> dids = new ArrayList<>();
         for (long did : diffChain) {
           if (fileDiffCache.containsKey(did)) {
             updateFileDiffInCache(did, FileDiffState.MERGED);
           } else {
+            dids.add(did);
             LOG.error("FileDiff {} is in chain but not in cache", did);
-            metaStore.updateFileDiff(did, FileDiffState.MERGED);
+            // metaStore.updateFileDiff(did, FileDiffState.MERGED);
           }
         }
+        metaStore.batchUpdateFileDiff(dids, FileDiffState.MERGED);
         diffChain.clear();
       }
     }

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -82,7 +82,7 @@ public class CopyScheduler extends ActionSchedulerService {
   private long mergeCountTh = 10;
   private int retryTh = 3;
   // Check interval of executorService
-  private long checkInterval = 150;
+  private long checkInterval = 500;
   // Base sync batch insert size
   private int batchSize = 500;
   // Cache of the file_diff

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -82,7 +82,7 @@ public class CopyScheduler extends ActionSchedulerService {
   private long mergeCountTh = 10;
   private int retryTh = 3;
   // Check interval of executorService
-  private long checkInterval = 500;
+  private long checkInterval;
   // Base sync batch insert size
   private int batchSize = 500;
   // Cache of the file_diff
@@ -106,18 +106,21 @@ public class CopyScheduler extends ActionSchedulerService {
     this.baseSyncQueue = new ConcurrentHashMap<>();
     this.overwriteQueue = new ConcurrentHashMap<>();
     this.executorService = Executors.newSingleThreadScheduledExecutor();
+    this.fileDiffCache = new ConcurrentHashMap<>();
+    this.fileDiffCacheChanged = new ConcurrentHashMap<>();
+    // Get conf or new default conf
     try {
       conf = getContext().getConf();
-      cacheSyncTh = conf.getInt(SmartConfKeys
-          .SMART_COPY_SCHEDULER_BASE_SYNC_BATCH,
-          SmartConfKeys.SMART_COPY_SCHEDULER_BASE_SYNC_BATCH_DEFAULT);
     } catch (NullPointerException e) {
       // SmartContext is empty
       conf = new Configuration();
     }
-    this.fileDiffCache = new ConcurrentHashMap<>();
-    this.fileDiffCacheChanged = new ConcurrentHashMap<>();
-
+    // Conf related parameters
+    cacheSyncTh = conf.getInt(SmartConfKeys
+            .SMART_COPY_SCHEDULER_BASE_SYNC_BATCH,
+        SmartConfKeys.SMART_COPY_SCHEDULER_BASE_SYNC_BATCH_DEFAULT);
+    checkInterval = conf.getLong(SmartConfKeys.SMART_COPY_SCHEDULER_CHECK_INTERVAL,
+        SmartConfKeys.SMART_COPY_SCHEDULER_CHECK_INTERVAL_DEFAULT);
     throttleInMb = conf.getLong(SmartConfKeys.SMART_ACTION_COPY_THROTTLE_MB_KEY,
         SmartConfKeys.SMART_ACTION_COPY_THROTTLE_MB_DEFAULT);
     if (throttleInMb > 0) {

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -1498,6 +1498,16 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
     }
   }
 
+  public boolean batchUpdateFileDiff(
+      List<Long> did, FileDiffState state)
+      throws MetaStoreException {
+    try {
+      return fileDiffDao.batchUpdate(did, state).length > 0;
+    } catch (Exception e) {
+      throw new MetaStoreException(e);
+    }
+  }
+
   public boolean updateFileDiff(long did,
       FileDiffState state, String parameters) throws MetaStoreException {
     try {

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -1540,17 +1540,16 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
     }
   }
 
-  public boolean updateFileDiff(List<FileDiff> fileDiffs)
+  public void updateFileDiff(List<FileDiff> fileDiffs)
     throws MetaStoreException {
     if (fileDiffs == null || fileDiffs.size() == 0) {
-      return true;
+      return;
     }
-    for (FileDiff fileDiff: fileDiffs) {
-      if (!updateFileDiff(fileDiff)) {
-        return false;
-      }
+    try {
+      fileDiffDao.update(fileDiffs.toArray(new FileDiff[fileDiffs.size()]));
+    } catch (Exception e) {
+      throw new MetaStoreException(e);
     }
-    return true;
   }
 
 

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileDiffDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileDiffDao.java
@@ -153,7 +153,8 @@ public class FileDiffDao {
   }
 
   public int[] batchUpdate(
-      final List<Long> dids, final List<FileDiffState> states, final List<String> parameters) {
+      final List<Long> dids, final List<FileDiffState> states,
+      final List<String> parameters) {
     JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 
     final String sql = "UPDATE " + TABLE_NAME + " SET state = ?, "
@@ -212,6 +213,37 @@ public class FileDiffDao {
     String sql = "UPDATE " + TABLE_NAME + " SET state = ?, "
         + "parameters = ? WHERE did = ?";
     return jdbcTemplate.update(sql, state.getValue(), parameters, did);
+  }
+
+  public int[] update(final FileDiff[] fileDiffs) {
+    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+    String sql = "UPDATE " + TABLE_NAME + " SET "
+        + "rid = ?, "
+        + "diff_type = ?, "
+        + "src = ?, "
+        + "parameters = ?, "
+        + "state = ?, "
+        + "create_time = ? "
+        + "WHERE did = ?";
+    return jdbcTemplate.batchUpdate(sql,
+        new BatchPreparedStatementSetter() {
+          @Override
+          public void setValues(PreparedStatement ps,
+              int i) throws SQLException {
+            ps.setLong(1, fileDiffs[i].getRuleId());
+            ps.setInt(2, fileDiffs[i].getDiffType().getValue());
+            ps.setString(3, fileDiffs[i].getSrc());
+            ps.setString(4, fileDiffs[i].getParametersJsonString());
+            ps.setInt(5, fileDiffs[i].getState().getValue());
+            ps.setLong(6, fileDiffs[i].getCreateTime());
+            ps.setLong(7, fileDiffs[i].getDiffId());
+          }
+
+          @Override
+          public int getBatchSize() {
+            return fileDiffs.length;
+          }
+        });
   }
 
   public int update(final FileDiff fileDiff) {

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileDiffDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileDiffDao.java
@@ -173,6 +173,27 @@ public class FileDiffDao {
     });
   }
 
+  public int[] batchUpdate(
+      final List<Long> dids, final FileDiffState state) {
+    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+
+    final String sql = "UPDATE " + TABLE_NAME + " SET state = ? "
+        + "WHERE did = ?";
+    return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+      @Override
+      public void setValues(PreparedStatement ps, int i) throws SQLException {
+        ps.setShort(1, (short) state.getValue());
+        ps.setLong(2, dids.get(i));
+      }
+
+      @Override
+      public int getBatchSize() {
+        return dids.size();
+      }
+    });
+  }
+
+
   public int update(long did, FileDiffState state) {
     JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
     String sql = "UPDATE " + TABLE_NAME + " SET state = ? WHERE did = ?";

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileDiffDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileDiffDao.java
@@ -100,6 +100,8 @@ public class TestFileDiffDao extends TestDaoUtil {
     fileInfoList = fileDiffDao.getAll();
 
     Assert.assertTrue(fileInfoList.get(0).getState().equals(FileDiffState.APPLIED));
+    fileDiffDao.batchUpdate(dids, FileDiffState.MERGED);
+    Assert.assertTrue(fileDiffDao.getAll().get(0).getState().equals(FileDiffState.MERGED));
 
   }
 

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileDiffDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileDiffDao.java
@@ -137,28 +137,38 @@ public class TestFileDiffDao extends TestDaoUtil {
 
   @Test
   public void testUpdate() {
-    FileDiff fileDiff = new FileDiff();
-    fileDiff.setDiffId(1);
-    fileDiff.setParameters(new HashMap<String, String>());
-    fileDiff.setSrc("test");
-    fileDiff.setState(FileDiffState.PENDING);
-    fileDiff.setDiffType(FileDiffType.APPEND);
-    fileDiff.setCreateTime(1);
-    fileDiffDao.insert(fileDiff);
+    FileDiff[] fileDiffs = new FileDiff[2];
+    fileDiffs[0] = new FileDiff();
+    fileDiffs[0].setDiffId(1);
+    fileDiffs[0].setRuleId(1);
+    fileDiffs[0].setParameters(new HashMap<String, String>());
+    fileDiffs[0].setSrc("test");
+    fileDiffs[0].setState(FileDiffState.PENDING);
+    fileDiffs[0].setDiffType(FileDiffType.APPEND);
+    fileDiffs[0].setCreateTime(1);
 
+    fileDiffs[1] = new FileDiff();
+    fileDiffs[1].setDiffId(2);
+    fileDiffs[0].setRuleId(1);
+    fileDiffs[1].setParameters(new HashMap<String, String>());
+    fileDiffs[1].setSrc("src");
+    fileDiffs[1].setState(FileDiffState.PENDING);
+    fileDiffs[1].setDiffType(FileDiffType.APPEND);
+    fileDiffs[1].setCreateTime(1);
+
+    fileDiffDao.insert(fileDiffs);
     fileDiffDao.update(1, FileDiffState.RUNNING);
-    fileDiff.setState(FileDiffState.RUNNING);
+    fileDiffs[0].setState(FileDiffState.RUNNING);
 
-    Assert.assertTrue(fileDiffDao.getById(1).equals(fileDiff));
-    Assert.assertTrue(fileDiffDao.getPendingDiff().size() == 0);
-    fileDiff.getParameters().put("-offset", "0");
-    fileDiffDao.update(1, FileDiffState.RUNNING, fileDiff.getParametersJsonString());
-    Assert.assertTrue(fileDiffDao.getById(1).equals(fileDiff));
-    fileDiff.setSrc("test1");
-    fileDiffDao.update(1, "test1");
-    Assert.assertTrue(fileDiffDao.getById(1).equals(fileDiff));
-    fileDiff.setRuleId(1L);
-    fileDiffDao.update(fileDiff);
-    Assert.assertTrue(fileDiffDao.getById(1).equals(fileDiff));
+    Assert.assertTrue(fileDiffDao.getById(1).equals(fileDiffs[0]));
+    Assert.assertTrue(fileDiffDao.getPendingDiff().size() == 1);
+    fileDiffs[0].getParameters().put("-offset", "0");
+    fileDiffs[0].setSrc("test1");
+    fileDiffs[1].setCreateTime(2);
+    fileDiffs[1].setRuleId(2);
+    fileDiffs[1].setDiffType(FileDiffType.RENAME);
+    fileDiffDao.update(fileDiffs);
+    Assert.assertTrue(fileDiffDao.getById(1).equals(fileDiffs[0]));
+    Assert.assertTrue(fileDiffDao.getById(2).equals(fileDiffs[1]));
   }
 }


### PR DESCRIPTION
* Add SMART_COPY_SCHEDULER_CHECK_INTERVAL in SmartConfKeys.
* Add batchUpdate (same state) for multiple fileDiffs, which can reduce access and increase efficiency.
