### PR TITLE
Solve #1754, fix file table not sync after set owner, group

### DIFF
--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventApplier.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventApplier.java
@@ -269,8 +269,11 @@ public class InotifyEventApplier {
           fileDiff.getParameters().put("-owner", "" + metadataUpdateEvent.getOwnerName());
           metaStore.insertFileDiff(fileDiff);
         }
-        //Todo
-        break;
+        return String.format(
+            "UPDATE file SET owner = '%s', owner_group = '%s' WHERE path = '%s';",
+            metadataUpdateEvent.getOwnerName(),
+            metadataUpdateEvent.getGroupName(),
+            metadataUpdateEvent.getPath());
       case PERMS:
         if (fileDiff != null) {
           fileDiff.getParameters().put("-permission", "" + metadataUpdateEvent.getPerms().toShort());

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyEventApplier.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyEventApplier.java
@@ -123,6 +123,18 @@ public class TestInotifyEventApplier extends TestDaoUtil {
     Assert.assertEquals(result4.getAccessTime(), 3);
     Assert.assertEquals(result4.getModificationTime(), 2);
 
+    Event meta1 =
+        new Event.MetadataUpdateEvent.Builder()
+            .path("/file")
+            .metadataType(Event.MetadataUpdateEvent.MetadataType.OWNER)
+            .ownerName("user1")
+            .groupName("cg1")
+            .build();
+    applier.apply(new Event[] {meta1});
+    result4 = metaStore.getFile().get(0);
+    Assert.assertEquals(result4.getOwner(), "user1");
+    Assert.assertEquals(result4.getGroup(), "cg1");
+
     Event.CreateEvent createEvent2 =
         new Event.CreateEvent.Builder()
             .iNodeType(Event.CreateEvent.INodeType.DIRECTORY)
@@ -165,7 +177,7 @@ public class TestInotifyEventApplier extends TestDaoUtil {
     Assert.assertEquals(metaStore.getFile().size(), 0);
     System.out.println("Files in table " + metaStore.getFile().size());
     List<FileDiff> fileDiffList = metaStore.getPendingDiff();
-    Assert.assertTrue(fileDiffList.size() == 4);
+    Assert.assertTrue(fileDiffList.size() == 5);
   }
 
   @Test


### PR DESCRIPTION
* Add MetadataUpdateEvent OWNER type support.
* Add UT for set owner and group.