### PR TITLE
Solve #1803, add failover support for rename

### DIFF
--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -55,7 +55,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 public class CopyScheduler extends ActionSchedulerService {
   static final Logger LOG =
@@ -718,10 +717,9 @@ public class CopyScheduler extends ActionSchedulerService {
         long did = fileDiff.getDiffId();
         if (fileDiff.getDiffType() == FileDiffType.APPEND) {
           String offset = fileDiff.getParameters().get("-offset");
-          if (offset != null && offset.equals("0") && diffChain.size() != 0) {
-            markAllDiffs();
-          }
-
+          // if (offset != null && offset.equals("0") && appendChain.size() != 0) {
+          //   markAllDiffs();
+          // }
           if (currAppendLength >= mergeLenTh ||
               appendChain.size() >= mergeCountTh) {
             mergeAppend();

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -859,7 +859,10 @@ public class CopyScheduler extends ActionSchedulerService {
           diffChain.add(0, fileDiff.getDiffId());
         } else {
           // Rename chain
+          fileLock.remove(filePath);
+          fileDiffChainMap.remove(filePath);
           setFilePath(newName);
+          fileDiffChainMap.put(newName, this);
           updateFileDiffInCache(fileDiff.getDiffId(), FileDiffState.APPLIED);
         }
         // Unlock file

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -858,6 +858,8 @@ public class CopyScheduler extends ActionSchedulerService {
         if (!isCreate) {
           diffChain.add(0, fileDiff.getDiffId());
         } else {
+          // Rename chain
+          setFilePath(newName);
           updateFileDiffInCache(fileDiff.getDiffId(), FileDiffState.APPLIED);
         }
         // Unlock file

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -843,8 +843,8 @@ public class CopyScheduler extends ActionSchedulerService {
         boolean isCreate = false;
         for (long did : appendChain) {
           FileDiff appendFileDiff = fileDiffCache.get(did);
-          if (fileDiff.getParameters().containsKey("-offset")) {
-            if (fileDiff.getParameters().get("-offset").equals("0")) {
+          if (appendFileDiff.getParameters().containsKey("-offset")) {
+            if (appendFileDiff.getParameters().get("-offset").equals("0")) {
               isCreate = true;
             }
           }

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -292,8 +292,10 @@ public class CopyScheduler extends ActionSchedulerService {
             // Todo maybe diff affects multiple files
             retryDiffMap.remove(did);
             // Add to direct Sync queue
-            baseSyncQueue.put(actionInfo.getArgs().get(SyncAction.SRC),
-                actionInfo.getArgs().get(SyncAction.DEST));
+            baseSyncQueue.put(fileDiff.getSrc(), actionInfo.getArgs().get(HdfsAction.FILE_PATH));
+            if (fileDiff.getDiffType() == FileDiffType.RENAME) {
+              baseSyncQueue.put(fileDiff.getParameters().get("-dest"), actionInfo.getArgs().get("-dest"));
+            }
           } else {
             retryDiffMap.put(did, curr + 1);
           }

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileDiffDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileDiffDao.java
@@ -101,7 +101,11 @@ public class TestFileDiffDao extends TestDaoUtil {
 
     Assert.assertTrue(fileInfoList.get(0).getState().equals(FileDiffState.APPLIED));
     fileDiffDao.batchUpdate(dids, FileDiffState.MERGED);
-    Assert.assertTrue(fileDiffDao.getAll().get(0).getState().equals(FileDiffState.MERGED));
+
+    fileInfoList = fileDiffDao.getAll();
+    for (int i = 0; i < 2; i++) {
+      Assert.assertTrue(fileInfoList.get(i).getState() == FileDiffState.MERGED);
+    }
 
   }
 


### PR DESCRIPTION
* Fix append and rename fail caused by 'put'.
* Add failover support for rename.
* Fix a bug in mergeRename.