### PR TITLE
Support parse kerberos principal name with hostname pattern.

### DIFF
--- a/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
+++ b/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
@@ -119,7 +119,9 @@ public class SmartAgent implements StatusReporter {
     UserGroupInformation.setConfiguration(conf);
 
     String keytabFilename = conf.get(SmartConfKeys.SMART_AGENT_KEYTAB_FILE_KEY);
-    String principal = conf.get(SmartConfKeys.SMART_AGENT_KERBEROS_PRINCIPAL_KEY);
+    String principalConfig = conf.get(SmartConfKeys.SMART_AGENT_KERBEROS_PRINCIPAL_KEY);
+    String principal =
+        org.apache.hadoop.security.SecurityUtil.getServerPrincipal(principalConfig, (String) null);
 
     SecurityUtil.loginUsingKeytab(keytabFilename, principal);
   }

--- a/smart-common/src/main/java/org/smartdata/utils/SecurityUtil.java
+++ b/smart-common/src/main/java/org/smartdata/utils/SecurityUtil.java
@@ -156,7 +156,9 @@ public class SecurityUtil {
       throw new IOException("Running in secure mode, but config doesn't have a keytab");
     }
     File keytabPath = new File(keytabFilename);
-    String principal = conf.get(SmartConfKeys.SMART_SERVER_KERBEROS_PRINCIPAL_KEY);
+    String principalConfig = conf.get(SmartConfKeys.SMART_SERVER_KERBEROS_PRINCIPAL_KEY);
+    String principal =
+        org.apache.hadoop.security.SecurityUtil.getServerPrincipal(principalConfig, (String) null);
     try {
       SecurityUtil.loginUsingKeytab(keytabPath.getAbsolutePath(), principal);
     } catch (IOException e) {

--- a/smart-server/src/main/java/org/smartdata/server/SmartServer.java
+++ b/smart-server/src/main/java/org/smartdata/server/SmartServer.java
@@ -285,7 +285,9 @@ public class SmartServer {
     UserGroupInformation.setConfiguration(conf);
 
     String keytabFilename = conf.get(SmartConfKeys.SMART_SERVER_KEYTAB_FILE_KEY);
-    String principal = conf.get(SmartConfKeys.SMART_SERVER_KERBEROS_PRINCIPAL_KEY);
+    String principalConfig = conf.get(SmartConfKeys.SMART_SERVER_KERBEROS_PRINCIPAL_KEY);
+    String principal =
+        org.apache.hadoop.security.SecurityUtil.getServerPrincipal(principalConfig, (String) null);
 
     SecurityUtil.loginUsingKeytab(keytabFilename, principal);
   }


### PR DESCRIPTION
Support parse kerberos principal name with hostname pattern like follows:
```
<property>
  <name>smart.agent.kerberos.principal</name>
  <value>smartagent/_HOST@HADOOP.COM</value>
</property>
```