### PR TITLE
Fix repeat SSM output directory in smart-dist dir

### DIFF
--- a/smart-dist/src/assemblies/bin.xml
+++ b/smart-dist/src/assemblies/bin.xml
@@ -10,11 +10,11 @@
     <fileSets>
         <fileSet>
             <directory>${basedir}/../bin</directory>
-            <outputDirectory>smart-data-${project.version}/bin</outputDirectory>
+            <outputDirectory>/bin</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${basedir}/../</directory>
-            <outputDirectory>smart-data-${project.version}</outputDirectory>
+            <outputDirectory>/</outputDirectory>
             <includes>
                 <include>LICENSE.txt</include>
                 <include>README.md</include>
@@ -22,36 +22,36 @@
         </fileSet>
         <fileSet>
             <directory>${basedir}/../conf</directory>
-            <outputDirectory>smart-data-${project.version}/conf</outputDirectory>
+            <outputDirectory>/conf</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${basedir}/../smart-zeppelin/interpreter</directory>
-            <outputDirectory>smart-data-${project.version}/interpreter</outputDirectory>
+            <outputDirectory>/interpreter</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${basedir}/../smart-zeppelin/notebook</directory>
-            <outputDirectory>smart-data-${project.version}/notebook</outputDirectory>
+            <outputDirectory>/notebook</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${basedir}/../smart-zeppelin/zeppelin-web/src/app/visualization</directory>
-            <outputDirectory>smart-data-${project.version}/lib/node_modules/zeppelin-vis</outputDirectory>
+            <outputDirectory>/lib/node_modules/zeppelin-vis</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${basedir}/../smart-zeppelin/zeppelin-web/src/app/tabledata</directory>
-            <outputDirectory>smart-data-${project.version}/lib/node_modules/zeppelin-tabledata</outputDirectory>
+            <outputDirectory>/lib/node_modules/zeppelin-tabledata</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${basedir}/../smart-zeppelin/zeppelin-web/dist</directory>
-            <outputDirectory>smart-data-${project.version}/dist</outputDirectory>
+            <outputDirectory>/dist</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${basedir}/../smart-blockec/target/native/lib</directory>
-            <outputDirectory>smart-data-${project.version}/native</outputDirectory>
+            <outputDirectory>/native</outputDirectory>
         </fileSet>
     </fileSets>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>smart-data-${project.version}/lib</outputDirectory>
+            <outputDirectory>/lib</outputDirectory>
             <useProjectArtifact>false</useProjectArtifact>
             <unpack>false</unpack>
             <scope>runtime</scope>


### PR DESCRIPTION
Previous directory tree:
- Smart-dist
    - target
       - smart-data-1.5.0-SNAPSHOT
           - smart-data-1.5.0-SNAPSHOT
               - conf
               - bin
               ...

Now:
- Smart-dist
    - target
       - smart-data-1.5.0-SNAPSHOT
           - conf
           - bin
           ...

