### PR TITLE
Correctly display node state on web UI

### DIFF
--- a/docs/ssm-deployment-guide.md
+++ b/docs/ssm-deployment-guide.md
@@ -248,7 +248,7 @@ Enter ${SMART_HOME} directory for running SSM. You can type `./bin/ssm version` 
 
 ##  **Start Smart Agent independently (Optional)**
 
-   If you want to scale out SSM cluster while keeping SSM service active, you can run the following command on Smart Server to start more Agents.
+   If you want to scale out SSM cluster while keeping SSM service active, you can run the following command on any node to start more Agents.
 
    `./bin/start-agent.sh [--host $hostname --config $config_dir --debug]`
 

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
@@ -127,6 +127,14 @@ public class SmartConf extends Configuration {
     return hostSet;
   }
 
+  /**
+   * Add host for newly launched standby server after SSM cluster
+   * becomes active.
+   */
+  public boolean addServerHosts(String hostname) {
+    return serverHosts.add(hostname);
+  }
+
   public Set<String> getServerHosts() {
     return serverHosts;
   }

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
@@ -41,6 +41,8 @@ public class SmartConf extends Configuration {
   private static final Logger LOG = LoggerFactory.getLogger(SmartConf.class);
   private final List<String> ignoreList;
   private final List<String> coverList;
+  // Include hosts configured in conf/agents and
+  // hosts added dynamically (by `start-agent.sh --host $host`)
   private Set<String> agentHosts;
   private Set<String> serverHosts;
 
@@ -127,6 +129,14 @@ public class SmartConf extends Configuration {
 
   public Set<String> getServerHosts() {
     return serverHosts;
+  }
+
+  /**
+   * Add host for newly launched agents after SSM cluster
+   * becomes active.
+   */
+  public boolean addAgentHost(String hostname) {
+    return agentHosts.add(hostname);
   }
 
   public Set<String> getAgentHosts() {

--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletDispatcher.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletDispatcher.java
@@ -457,11 +457,19 @@ public class CmdletDispatcher {
   }
 
   public void onNodeMessage(NodeMessage msg, boolean isAdd) {
+
     if (disableLocalExec && msg.getNodeInfo().getExecutorType() == ExecutorType.LOCAL) {
       return;
     }
 
-    // New agent can be added to an active SSM cluster by executing start-agent.sh.
+    // New standby server can be added to an active SSM cluster by
+    // executing start-standby-server.sh.
+    if (msg.getNodeInfo().getExecutorType() == ExecutorType.REMOTE_SSM) {
+      conf.addServerHosts(msg.getNodeInfo().getHost());
+    }
+
+    // New agent can be added to an active SSM cluster by executing
+    // start-agent.sh.
     if (msg.getNodeInfo().getExecutorType() == ExecutorType.AGENT) {
       conf.addAgentHost(msg.getNodeInfo().getHost());
     }

--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletDispatcher.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletDispatcher.java
@@ -86,6 +86,8 @@ public class CmdletDispatcher {
   private List<List<String>> cmdExecSrvNodeIds = new ArrayList<>();
   private String[] completeOn = new String[ExecutorType.values().length];
 
+  private SmartConf conf;
+
   public CmdletDispatcher(SmartContext smartContext, CmdletManager cmdletManager,
       Queue<Long> scheduledCmdlets, Map<Long, LaunchCmdlet> idToLaunchCmdlet,
       List<Long> runningCmdlets, ListMultimap<String, ActionScheduler> schedulers) {
@@ -119,7 +121,7 @@ public class CmdletDispatcher {
       registerExecutorService(exe);
     }
 
-    SmartConf conf = smartContext.getConf();
+    this.conf = smartContext.getConf();
     logDispResult = conf.getBoolean(
         SmartConfKeys.SMART_CMDLET_DISPATCHER_LOG_DISP_RESULT_KEY,
         SmartConfKeys.SMART_CMDLET_DISPATCHER_LOG_DISP_RESULT_DEFAULT);
@@ -457,6 +459,11 @@ public class CmdletDispatcher {
   public void onNodeMessage(NodeMessage msg, boolean isAdd) {
     if (disableLocalExec && msg.getNodeInfo().getExecutorType() == ExecutorType.LOCAL) {
       return;
+    }
+
+    // New agent can be added to an active SSM cluster by executing start-agent.sh.
+    if (msg.getNodeInfo().getExecutorType() == ExecutorType.AGENT) {
+      conf.addAgentHost(msg.getNodeInfo().getHost());
     }
 
     synchronized (cmdExecSrvInsts) {

--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletDispatcherHelper.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletDispatcherHelper.java
@@ -71,6 +71,8 @@ public class CmdletDispatcherHelper {
   private void onNodeMessage(NodeMessage msg, boolean add) {
     synchronized (msgs) {
       if (dispatcher == null) {
+        // Dispatcher is not registered, but we need to keep message
+        // in msgs and ask dispatcher to tackle in #register later.
         msgs.add(msg);
         opers.add(add);
       } else {

--- a/smart-zeppelin/zeppelin-web/src/app/dashboard/views/cluster/nodeinfo/nodes.html
+++ b/smart-zeppelin/zeppelin-web/src/app/dashboard/views/cluster/nodeinfo/nodes.html
@@ -65,7 +65,7 @@ under the License.
       <td>{{
         isLive
         ? (node.nodeInfo.id)
-        : node.nodeInfo.host + (node.type === "agent" ? "@agent" : "@server")
+        : (node.type === "agent" ? "Agent@" : "Server@") + node.nodeInfo.host
         }}</td>
       <td>{{isLive ? node.registTime : '-'}}</td>
       <td>{{isLive ? node.numExecutors : '-'}}</td>

--- a/smart-zeppelin/zeppelin-web/src/app/dashboard/views/cluster/nodeinfo/nodes.html
+++ b/smart-zeppelin/zeppelin-web/src/app/dashboard/views/cluster/nodeinfo/nodes.html
@@ -71,7 +71,11 @@ under the License.
       <td>{{isLive ? node.numExecutors : '-'}}</td>
       <td>{{isLive ? node.cmdletsInExecution : '-'}}</td>
       <td>{{isLive ? node.cmdletsExecuted : '-'}}</td>
-      <td class="statusPoint-container"><div class="statusPoint {{isLive ? 'btn-success' : 'btn-danger'}}"></div></td>
+      <td>
+        <div class="statusPoint {{isLive ? 'btn-success' : 'btn-danger'}}"
+               style="margin:auto; display:block">
+        </div>
+      </td>
     </tr>
     </tbody>
   </table>

--- a/smart-zeppelin/zeppelin-web/src/app/dashboard/views/cluster/nodeinfo/nodes.js
+++ b/smart-zeppelin/zeppelin-web/src/app/dashboard/views/cluster/nodeinfo/nodes.js
@@ -22,29 +22,26 @@ angular.module('zeppelinWebApp')
   NodesCtrl.$inject = ['$scope', '$filter', 'nodes0', 'serverHosts', 'agentHosts'];
   function NodesCtrl($scope, $filter, nodes0, serverHosts, agentHosts) {
     $scope.nodes = nodes0.body;
-    // Smart Server hosts configured in conf/servers, obtained from SmartConf.
+    // Smart Server hosts obtained from SmartConf.
     $scope.serverHosts = serverHosts.body;
-    // Smart Server hosts configured in conf/agents, obtained from SmartConf.
+    // Smart Agent hosts obtained from SmartConf.
     $scope.agentHosts = agentHosts.body;
 
     angular.forEach($scope.nodes, function (data, index) {
-      if ('maxInExecution' in data) {
+      if (data.nodeInfo.executorType == "LOCAL" ||
+      data.nodeInfo.executorType == "REMOTE_SSM") {
         let index = $scope.serverHosts.indexOf(data.nodeInfo.host);
         if (index >= 0) {
           data.isLive = true;
-          data.type = 'server';
+          //data.type = 'server';
           $scope.serverHosts.splice(index, 1);
         }
       } else {
         let index = $scope.agentHosts.indexOf(data.nodeInfo.host);
         if (index >= 0) {
           data.isLive = true;
-          data.type = 'agent';
+          //data.type = 'agent';
           $scope.agentHosts.splice(index, 1);
-        } else {
-          // Set the node status even though it is not included in agentHosts.
-          data.isLive = true;
-          data.type = 'agent';
         }
       }
     });

--- a/smart-zeppelin/zeppelin-web/src/app/dashboard/views/cluster/nodeinfo/nodes.js
+++ b/smart-zeppelin/zeppelin-web/src/app/dashboard/views/cluster/nodeinfo/nodes.js
@@ -42,8 +42,7 @@ angular.module('zeppelinWebApp')
           data.type = 'agent';
           $scope.agentHosts.splice(index, 1);
         } else {
-          // The node host is not added in conf/servers,
-          // but it may be launched after SSM cluster becomes active.
+          // Set the node status even though it is not included in agentHosts.
           data.isLive = true;
           data.type = 'agent';
         }

--- a/smart-zeppelin/zeppelin-web/src/app/dashboard/views/cluster/nodeinfo/nodes.js
+++ b/smart-zeppelin/zeppelin-web/src/app/dashboard/views/cluster/nodeinfo/nodes.js
@@ -22,7 +22,9 @@ angular.module('zeppelinWebApp')
   NodesCtrl.$inject = ['$scope', '$filter', 'nodes0', 'serverHosts', 'agentHosts'];
   function NodesCtrl($scope, $filter, nodes0, serverHosts, agentHosts) {
     $scope.nodes = nodes0.body;
+    // Smart Server hosts configured in conf/servers, obtained from SmartConf.
     $scope.serverHosts = serverHosts.body;
+    // Smart Server hosts configured in conf/agents, obtained from SmartConf.
     $scope.agentHosts = agentHosts.body;
 
     angular.forEach($scope.nodes, function (data, index) {
@@ -39,6 +41,11 @@ angular.module('zeppelinWebApp')
           data.isLive = true;
           data.type = 'agent';
           $scope.agentHosts.splice(index, 1);
+        } else {
+          // The node host is not added in conf/servers,
+          // but it may be launched after SSM cluster becomes active.
+          data.isLive = true;
+          data.type = 'agent';
         }
       }
     });


### PR DESCRIPTION
Some cases:
1. User deployed SSM agents on some nodes with adding their host names in conf/agents. After SSM cluster becomes active, all nodes should be correctly described on node info page, i.e., live or dead.
2. For dead nodes in the 1st item, after user successfully launches them, their state should become live in node info page.
3. User tries to scale out active SSM cluster by deploying agents on some new nodes, these new nodes should also be correctly described on node info page, i.e., live or dead.
4. The configured standby server should also be correctly displayed. If the standby server crashes, its state on node info page should be dead. After successfully launched, the standby server's state should become live again.
5. Considering two Smart Server are configured, if the active Smart Server is dead, the standby server will work as active server. The node info page should reflect this change. User can relaunch the Smart Server that once serves as active server. After relaunched, it will work as standby Smart Server. The node info page should also correctly reflect each node's role.