### PR TITLE
Enable SmartClient to find active smart server with try in HA mode

### DIFF
--- a/docs/ssm-deployment-guide.md
+++ b/docs/ssm-deployment-guide.md
@@ -320,10 +320,11 @@ Add property `fs.hdfs.impl` to point to Smart Server which provides "Smart File 
 ### hdfs-site.xml changes  
 
 Add property `smart.server.rpc.address` to point to the installed Smart Server. Add the following content to the `hdfs-site.xml`. Default Smart Server RPC port is `7042`.
+If SSM HA mode is enabled, more than one Smart Server address can be specified with comma delimited.
 ```xml
     <property>
         <name>smart.server.rpc.address</name>
-        <value>ssm-server-ip:rpc-port</value>
+        <value>smart-server-hostname:rpc-port</value>
     </property>
 ```
 
@@ -408,10 +409,11 @@ Add property `fs.hdfs.impl` to `core-site.xml` using Cloudera Manager to point t
 Add property `smart.server.rpc.address` to `hdfs-site.xml` using Cloudera Manager to point to the installed Smart Server.
  1.    In the Cloudera Manager Admin Console, click the HDFS indicator in the top navigation bar. Click the Configuration button.
  2.    Search `HDFS Service Advanced Configuration Snippet (Safety Valve) for hdfs-site.xml` configuration, and add the following xml context. The  default Smart Server RPC port is `7042`.
+       If SSM HA mode is enabled, more than one Smart Server address can be specified with comma delimited.
 ```xml
     <property>
         <name>smart.server.rpc.address</name>
-        <value>ssm-server-ip:rpc-port</value>
+        <value>smart-server-hostname:rpc-port</value>
     </property>
 ```
  3.    Search `HDFS Client Advanced Configuration Snippet (Safety Valve) for hdfs-site.xml` configuration, and add the following xml context. The  default Smart Server RPC port is `7042`.

--- a/smart-client/src/main/java/org/smartdata/client/SmartClient.java
+++ b/smart-client/src/main/java/org/smartdata/client/SmartClient.java
@@ -43,9 +43,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public class SmartClient implements java.io.Closeable, SmartClientProtocol {
   private static final long VERSION = 1;
   private Configuration conf;
-  /** The server queue keeps server's order according to active status **/
+  /** The server queue keeps server's order according to active status. **/
   private Deque<SmartClientProtocol> serverQue;
-  /** The map from server to its rpc address in "hostname:port" format **/
+  /** The map from server to its rpc address in "hostname:port" format. **/
   private Map<SmartClientProtocol, String> serverToRpcAddr;
   private volatile boolean running = true;
   private List<String> ignoreAccessEventDirs;
@@ -130,7 +130,7 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
    * smart servers can be configured. If fail to connect to one server,
    * this method will pick up the next one from a queue to try again. If
    * all servers cannot be connected, an exception will be thrown.
-   *
+   * <p></p>
    * We assume Configuration generally has only one instance. If active
    * server has been changed found here, Configuration object will reset
    * the value for SMART_SERVER_RPC_ADDRESS_KEY. Thus, next time a

--- a/smart-client/src/main/java/org/smartdata/client/SmartClient.java
+++ b/smart-client/src/main/java/org/smartdata/client/SmartClient.java
@@ -144,11 +144,12 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
    * this method will pick up the next one from a queue to try again. If
    * all servers cannot be connected, an exception will be thrown.
    * <p></p>
-   * We assume Configuration generally has only one instance. If active
-   * server has been changed found here, this method will reset the value
-   * for SMART_SERVER_RPC_ADDRESS_KEY in Configuration object. Thus, next
-   * time a SmartClient is created, the active server will be put in the
-   * head of queue and will be picked up firstly.
+   * Generally, Configuration class has only one instance. If this method
+   * finds active server has been changed, it will reset the value for
+   * property SMART_SERVER_RPC_ADDRESS_KEY in Configuration instance. Thus,
+   * next time a SmartClient is created with this Configuration instance,
+   * active server will be put in the head of a queue and it will be picked
+   * up firstly.
    *
    * @param event
    * @throws IOException

--- a/smart-client/src/main/java/org/smartdata/client/SmartClient.java
+++ b/smart-client/src/main/java/org/smartdata/client/SmartClient.java
@@ -130,8 +130,8 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
           triedServerNum++;
           // If all servers has been tried, interrupt and throw the exception.
           if (triedServerNum == serverQue.size()) {
-            throw new ConnectException("Tried to connect to configured SSM " +
-                "server(s), but failed." + e.getMessage());
+            throw new ConnectException("Tried to connect to configured SSM "
+                + "server(s), but failed." + e.getMessage());
           }
           // Put the first server to last, and will pick the second one to try.
           serverQue.addLast(serverQue.pollFirst());

--- a/smart-client/src/main/java/org/smartdata/client/SmartClient.java
+++ b/smart-client/src/main/java/org/smartdata/client/SmartClient.java
@@ -27,6 +27,7 @@ import org.smartdata.model.NormalFileState;
 import org.smartdata.protocol.SmartClientProtocol;
 import org.smartdata.protocol.protobuffer.ClientProtocolClientSideTranslator;
 import org.smartdata.protocol.protobuffer.ClientProtocolProtoBuffer;
+import org.smartdata.utils.StringUtil;
 
 import java.io.IOException;
 import java.net.ConnectException;
@@ -42,7 +43,10 @@ import java.util.concurrent.ConcurrentHashMap;
 public class SmartClient implements java.io.Closeable, SmartClientProtocol {
   private static final long VERSION = 1;
   private Configuration conf;
+  /** The server queue keeps server's order according to active status **/
   private Deque<SmartClientProtocol> serverQue;
+  /** The map from server to its rpc address in "hostname:port" format **/
+  private Map<SmartClientProtocol, String> serverToRpcAddr;
   private volatile boolean running = true;
   private List<String> ignoreAccessEventDirs;
   private Map<String, Integer> singleIgnoreList;
@@ -50,23 +54,27 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
 
   public SmartClient(Configuration conf) throws IOException {
     this.conf = conf;
-    String rpcConfValue = conf.get(SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY);
-    if (rpcConfValue == null) {
+    String[] rpcConfValue =
+        conf.getTrimmedStrings(SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY);
+    if (rpcConfValue == null || rpcConfValue.length == 0) {
       throw new IOException("SmartServer address not found. Please configure "
           + "it through " + SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY);
     }
 
-    String[] strings = rpcConfValue.split(":");
-    InetSocketAddress address;
-    try {
-      address = new InetSocketAddress(
-          strings[strings.length - 2],
-          Integer.parseInt(strings[strings.length - 1]));
-    } catch (Exception e) {
-      throw new IOException("Incorrect SmartServer address. Please follow the "
-          + "IP/Hostname:Port format");
+    List<InetSocketAddress> addrList = new LinkedList<>();
+    for (String rpcValue : rpcConfValue) {
+      String[] hostAndPort = rpcValue.split(":");
+      try {
+        InetSocketAddress smartServerAddress = new InetSocketAddress(
+            hostAndPort[hostAndPort.length - 2],
+            Integer.parseInt(hostAndPort[hostAndPort.length - 1]));
+        addrList.add(smartServerAddress);
+      } catch (Exception e) {
+        throw new IOException("Incorrect SmartServer address. Please follow "
+            + "IP/Hostname:Port format");
+      }
     }
-    initialize(new InetSocketAddress[]{address});
+    initialize(addrList.toArray(new InetSocketAddress[addrList.size()]));
   }
 
   public SmartClient(Configuration conf, InetSocketAddress address)
@@ -85,10 +93,12 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
     this.serverQue = new LinkedList<>();
     RPC.setProtocolEngine(conf, ClientProtocolProtoBuffer.class,
         ProtobufRpcEngine.class);
-    for (InetSocketAddress address : addrs) {
+    for (InetSocketAddress addr : addrs) {
       ClientProtocolProtoBuffer proxy = RPC.getProxy(
-          ClientProtocolProtoBuffer.class, VERSION, address, conf);
-      serverQue.addLast(new ClientProtocolClientSideTranslator(proxy));
+          ClientProtocolProtoBuffer.class, VERSION, addr, conf);
+      SmartClientProtocol server = new ClientProtocolClientSideTranslator(proxy);
+      serverQue.addLast(server);
+      serverToRpcAddr.put(server, addr.toString());
     }
 
     // The below two properties should be configured on HDFS side
@@ -99,10 +109,10 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
         SmartConfKeys.SMART_COVER_DIRS_KEY);
     ignoreAccessEventDirs = new ArrayList<>();
     coverAccessEventDirs = new ArrayList<>();
-    for (String s: ignoreDirs) {
+    for (String s : ignoreDirs) {
       ignoreAccessEventDirs.add(s + (s.endsWith("/") ? "" : "/"));
     }
-    for (String s: coverDirs) {
+    for (String s : coverDirs) {
       coverAccessEventDirs.add(s + (s.endsWith("/") ? "" : "/"));
     }
 
@@ -115,25 +125,52 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
     }
   }
 
+  /**
+   * Reports access count event to smart server. In SSM HA mode, multiple
+   * smart servers can be configured. If fail to connect to one server,
+   * this method will pick up the next one from a queue to try again. If
+   * all servers cannot be connected, an exception will be thrown.
+   *
+   * We assume Configuration generally has only one instance. If active
+   * server has been changed found here, Configuration object will reset
+   * the value for SMART_SERVER_RPC_ADDRESS_KEY. Thus, next time a
+   * SmartClient is created, the active server will be put in the head of
+   * queue and will be picked up firstly.
+   *
+   * @param event
+   * @throws IOException
+   */
   @Override
   public void reportFileAccessEvent(FileAccessEvent event)
       throws IOException {
     if (!shouldIgnore(event.getPath())) {
       checkOpen();
-      int triedServerNum = 0;
+      int failedServerNum = 0;
       while (true) {
         try {
           SmartClientProtocol server = serverQue.getFirst();
           server.reportFileAccessEvent(event);
+
+          // Reset smart server address in conf to reflect
+          // the changes of active smart server.
+          if (failedServerNum != 0) {
+            List<String> rpcAddrs = new LinkedList<>();
+            for (SmartClientProtocol s : serverQue) {
+              rpcAddrs.add(serverToRpcAddr.get(s));
+            }
+            conf.set(SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY,
+                StringUtil.join(",", rpcAddrs));
+          }
           break;
         } catch (ConnectException e) {
-          triedServerNum++;
-          // If all servers has been tried, interrupt and throw the exception.
-          if (triedServerNum == serverQue.size()) {
+          failedServerNum++;
+          // If all servers has been tried but still fail,
+          // throw an exception.
+          if (failedServerNum == serverQue.size()) {
             throw new ConnectException("Tried to connect to configured SSM "
                 + "server(s), but failed." + e.getMessage());
           }
-          // Put the first server to last, and will pick the second one to try.
+          // Move the first server to last.
           serverQue.addLast(serverQue.pollFirst());
         }
       }

--- a/smart-client/src/main/java/org/smartdata/client/SmartClient.java
+++ b/smart-client/src/main/java/org/smartdata/client/SmartClient.java
@@ -86,12 +86,24 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
   public SmartClient(Configuration conf, InetSocketAddress address)
       throws IOException {
     this.conf = conf;
+    this.serverQue = new LinkedList<>();
+    this.serverToRpcAddr = new HashMap<>();
+    this.ignoreAccessEventDirs = new ArrayList<>();
+    this.coverAccessEventDirs = new ArrayList<>();
+    this.singleIgnoreList = new ConcurrentHashMap<>(200);
+
     initialize(new InetSocketAddress[]{address});
   }
 
   public SmartClient(Configuration conf, InetSocketAddress[] addrs)
       throws IOException {
     this.conf = conf;
+    this.serverQue = new LinkedList<>();
+    this.serverToRpcAddr = new HashMap<>();
+    this.ignoreAccessEventDirs = new ArrayList<>();
+    this.coverAccessEventDirs = new ArrayList<>();
+    this.singleIgnoreList = new ConcurrentHashMap<>(200);
+
     initialize(addrs);
   }
 
@@ -133,10 +145,10 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
    * all servers cannot be connected, an exception will be thrown.
    * <p></p>
    * We assume Configuration generally has only one instance. If active
-   * server has been changed found here, Configuration object will reset
-   * the value for SMART_SERVER_RPC_ADDRESS_KEY. Thus, next time a
-   * SmartClient is created, the active server will be put in the head of
-   * queue and will be picked up firstly.
+   * server has been changed found here, this method will reset the value
+   * for SMART_SERVER_RPC_ADDRESS_KEY in Configuration object. Thus, next
+   * time a SmartClient is created, the active server will be put in the
+   * head of queue and will be picked up firstly.
    *
    * @param event
    * @throws IOException

--- a/smart-hadoop-support/smart-hadoop-client-2.7/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
+++ b/smart-hadoop-support/smart-hadoop-client-2.7/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
@@ -88,24 +88,7 @@ public class SmartFileSystem extends DistributedFileSystem {
   @Override
   public void initialize(URI uri, Configuration conf) throws IOException {
     super.initialize(uri, conf);
-
-    String rpcConfValue = conf.get(SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY);
-    if (rpcConfValue == null) {
-      throw new IOException("SmartServer address not found. Please configure "
-          + "it through " + SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY);
-    }
-
-    String[] strings = rpcConfValue.split(":");
-    InetSocketAddress smartServerAddress;
-    try {
-      smartServerAddress = new InetSocketAddress(
-          strings[strings.length - 2],
-          Integer.parseInt(strings[strings.length - 1]));
-    } catch (Exception e) {
-      throw new IOException("Incorrect SmartServer address. Please follow the "
-          + "IP/Hostname:Port format");
-    }
-    this.smartDFSClient = new SmartDFSClient(conf, smartServerAddress);
+    this.smartDFSClient = new SmartDFSClient(conf);
   }
 
   @Override

--- a/smart-hadoop-support/smart-hadoop-client-2.7/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
+++ b/smart-hadoop-support/smart-hadoop-client-2.7/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
@@ -64,7 +64,7 @@ import java.util.List;
  * 2. Copy these jar files to HDFS classpath
  * 3. Reconfigure HDFS
  *    Please do the following configurations,
- *    1. core-site.xml
+ *    1) core-site.xml
  *    Change property "fs.hdfs.impl" value, to point to the Smart Server provided
  *    "Smart File System".
  *    <property>
@@ -72,8 +72,10 @@ import java.util.List;
  *      <value>org.smartdata.hadoop.filesystem.SmartFileSystem</value>
  *      <description>The FileSystem for hdfs URL</description>
  *    </property>
- *    2. hdfs-site.xml
+ *    2) hdfs-site.xml
  *    Add property "smart.server.rpc.adddress" to point to Smart Server.
+ *    If SSM HA mode is enabled, more than one Smart Server address can
+ *    be specified with comma delimited.
  *    <property>
  *      <name>smart.server.rpc.address</name>
  *      <value>127.0.0.1:7042</value>

--- a/smart-hadoop-support/smart-hadoop-client-3.1/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
+++ b/smart-hadoop-support/smart-hadoop-client-3.1/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
@@ -64,16 +64,18 @@ import java.util.List;
  * 2. Copy these jar files to HDFS classpath
  * 3. Reconfigure HDFS
  *    Please do the following configurations,
- *    1. core-site.xml
- *    Change property "fs.hdfs.impl" value, to point to the Smart Server provided
- *    "Smart File System".
+ *    1) core-site.xml
+ *    Change property "fs.hdfs.impl" value, to point "Smart File System",
+ *    provided by SSM.
  *    <property>
  *      <name>fs.hdfs.impl</name>
  *      <value>org.smartdata.hadoop.filesystem.SmartFileSystem</value>
  *      <description>The FileSystem for hdfs URL</description>
  *    </property>
- *    2. hdfs-site.xml
+ *    2) hdfs-site.xml
  *    Add property "smart.server.rpc.address" to point to Smart Server.
+ *    If SSM HA mode is enabled, more than one Smart Server address can
+ *    be specified with comma delimited.
  *    <property>
  *      <name>smart.server.rpc.address</name>
  *      <value>127.0.0.1:7042</value>

--- a/smart-hadoop-support/smart-hadoop-client-3.1/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
+++ b/smart-hadoop-support/smart-hadoop-client-3.1/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
@@ -105,12 +105,12 @@ public class SmartFileSystem extends DistributedFileSystem {
             Integer.parseInt(hostAndPort[hostAndPort.length - 1]));
         addrList.add(smartServerAddress);
       } catch (Exception e) {
-        throw new IOException("Incorrect SmartServer address. Please follow the "
+        throw new IOException("Incorrect SmartServer address. Please follow "
             + "IP/Hostname:Port format");
       }
     }
     this.smartDFSClient = new SmartDFSClient(conf,
-        (InetSocketAddress[]) addrList.toArray());
+        addrList.toArray(new InetSocketAddress[addrList.size()]));
   }
 
   @Override

--- a/smart-hadoop-support/smart-hadoop-client-3.1/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
+++ b/smart-hadoop-support/smart-hadoop-client-3.1/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
@@ -89,28 +89,7 @@ public class SmartFileSystem extends DistributedFileSystem {
   public void initialize(URI uri, Configuration conf) throws IOException {
     super.initialize(uri, conf);
 
-    String[] rpcConfValue =
-        conf.getTrimmedStrings(SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY);
-    if (rpcConfValue == null) {
-      throw new IOException("SmartServer address not found. Please configure "
-          + "it through " + SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY);
-    }
-
-    List<InetSocketAddress> addrList = new LinkedList<>();
-    for (String rpcValue : rpcConfValue) {
-      String[] hostAndPort = rpcValue.split(":");
-      try {
-        InetSocketAddress smartServerAddress = new InetSocketAddress(
-            hostAndPort[hostAndPort.length - 2],
-            Integer.parseInt(hostAndPort[hostAndPort.length - 1]));
-        addrList.add(smartServerAddress);
-      } catch (Exception e) {
-        throw new IOException("Incorrect SmartServer address. Please follow "
-            + "IP/Hostname:Port format");
-      }
-    }
-    this.smartDFSClient = new SmartDFSClient(conf,
-        addrList.toArray(new InetSocketAddress[addrList.size()]));
+    this.smartDFSClient = new SmartDFSClient(conf);
   }
 
   @Override

--- a/smart-hadoop-support/smart-hadoop-client-3.1/src/main/java/org/smartdata/hdfs/client/SmartDFSClient.java
+++ b/smart-hadoop-support/smart-hadoop-client-3.1/src/main/java/org/smartdata/hdfs/client/SmartDFSClient.java
@@ -110,7 +110,7 @@ public class SmartDFSClient extends DFSClient {
   }
 
   public SmartDFSClient(Configuration conf,
-      InetSocketAddress smartServerAddress) throws IOException {
+      InetSocketAddress[] smartServerAddress) throws IOException {
     super(conf);
     if (isSmartClientDisabled()) {
       return;

--- a/smart-hadoop-support/smart-hadoop-client-cdh-2.6/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
+++ b/smart-hadoop-support/smart-hadoop-client-cdh-2.6/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
@@ -88,24 +88,7 @@ public class SmartFileSystem extends DistributedFileSystem {
   @Override
   public void initialize(URI uri, Configuration conf) throws IOException {
     super.initialize(uri, conf);
-
-    String rpcConfValue = conf.get(SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY);
-    if (rpcConfValue == null) {
-      throw new IOException("SmartServer address not found. Please configure "
-          + "it through " + SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY);
-    }
-
-    String[] strings = rpcConfValue.split(":");
-    InetSocketAddress smartServerAddress;
-    try {
-      smartServerAddress = new InetSocketAddress(
-          strings[strings.length - 2],
-          Integer.parseInt(strings[strings.length - 1]));
-    } catch (Exception e) {
-      throw new IOException("Incorrect SmartServer address. Please follow the "
-          + "IP/Hostname:Port format");
-    }
-    this.smartDFSClient = new SmartDFSClient(conf, smartServerAddress);
+    this.smartDFSClient = new SmartDFSClient(conf);
   }
 
   @Override

--- a/smart-hadoop-support/smart-hadoop-client-cdh-2.6/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
+++ b/smart-hadoop-support/smart-hadoop-client-cdh-2.6/src/main/java/org/smartdata/hadoop/filesystem/SmartFileSystem.java
@@ -64,7 +64,7 @@ import java.util.List;
  * 2. Copy these jar files to HDFS classpath
  * 3. Reconfigure HDFS
  *    Please do the following configurations,
- *    1. core-site.xml
+ *    1) core-site.xml
  *    Change property "fs.hdfs.impl" value, to point to the Smart Server provided
  *    "Smart File System".
  *    <property>
@@ -72,8 +72,10 @@ import java.util.List;
  *      <value>org.smartdata.hadoop.filesystem.SmartFileSystem</value>
  *      <description>The FileSystem for hdfs URL</description>
  *    </property>
- *    2. hdfs-site.xml
+ *    2) hdfs-site.xml
  *    Add property "smart.server.rpc.adddress" to point to Smart Server.
+ *    If SSM HA mode is enabled, more than one Smart Server address can
+ *    be specified with comma delimited.
  *    <property>
  *      <name>smart.server.rpc.address</name>
  *      <value>127.0.0.1:7042</value>


### PR DESCRIPTION
In the current trunk branch, SmartDFSClient can only instantiate a SmartClient with one smart server rpc address which is supposed the active server's. However, if active server fails, a connection exception will be thrown during SmartClient still trying to connect this server. Inside SSM, the active server address will be reset during a standby server is shifting to the new role. But on application side where SmartDFSClient is used to access HDFS data, the above issue will occur.