### PR TITLE
Handle master/agent association exception

### DIFF
--- a/docs/ssm-developer-guide.md
+++ b/docs/ssm-developer-guide.md
@@ -50,3 +50,10 @@ socket message to your local computer 8008 port. And you also need to change the
 server host name with your local computer's host name .
 
   `ssh -L 8008:{REMOTE_SERVER}:8008 {USER}@{PROXY_HOST} -N`
+
+
+## **Third-party Lib's Doc Link**
+
+[Hazelcast](https://docs.hazelcast.org/docs/3.7.8/manual/pdf/hazelcast-documentation-3.7.8.pdf)
+
+[Akka](https://doc.akka.io/docs/akka/2.3/AkkaJava.pdf)

--- a/smart-agent/pom.xml
+++ b/smart-agent/pom.xml
@@ -94,14 +94,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/smart-agent/pom.xml
+++ b/smart-agent/pom.xml
@@ -94,6 +94,14 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
+++ b/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
@@ -358,8 +358,8 @@ public class SmartAgent implements StatusReporter {
               AgentUtils.getFullPath(getContext().system(), getSelf().path()));
           Serve serveContext = new Serve();
           getContext().become(serveContext);
-        } else if (message instanceof DisassociatedEvent ||
-            message instanceof AssociationErrorEvent) {
+        } else if (message instanceof DisassociatedEvent
+            || message instanceof AssociationErrorEvent) {
           AssociationEvent associEvent = (AssociationEvent) message;
           // Event for failed master can be repeated published. So ignore it.
           if (!master.path().address().equals(
@@ -431,8 +431,8 @@ public class SmartAgent implements StatusReporter {
                 + "a new master...", getSender());
             getContext().become(new WaitForFindMaster(findMaster()));
           }
-        } else if (message instanceof DisassociatedEvent ||
-            message instanceof AssociationErrorEvent) {
+        } else if (message instanceof DisassociatedEvent
+            || message instanceof AssociationErrorEvent) {
           AssociationEvent associEvent = (AssociationEvent) message;
           // Event for failed master can be repeated published. So ignore it.
           if (!master.path().address().equals(

--- a/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
+++ b/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
@@ -342,6 +342,11 @@ public class SmartAgent implements StatusReporter {
           getContext().become(new Serve());
         } else if (message instanceof DisassociatedEvent) {
           DisassociatedEvent disassociEvent = (DisassociatedEvent) message;
+          // Event for failed master can be repeated published. So ignore it.
+          if (!master.path().address().equals(
+              disassociEvent.remoteAddress())) {
+            return;
+          }
           LOG.warn("Received event: {}, details: {}",
               disassociEvent.eventName(), disassociEvent.toString());
           LOG.warn("Go back to the preceding context to find master..");
@@ -349,6 +354,11 @@ public class SmartAgent implements StatusReporter {
         } else if (message instanceof AssociationErrorEvent) {
           AssociationErrorEvent associErrorEvent =
               (AssociationErrorEvent) message;
+          // Event for failed master can be repeated published. So ignore it.
+          if (!master.path().address().equals(
+              associErrorEvent.remoteAddress())) {
+            return;
+          }
           LOG.warn("Received event: {}, details: {}",
               associErrorEvent.eventName(), associErrorEvent.toString());
           LOG.warn("Go back to the preceding context to find master..");
@@ -395,6 +405,11 @@ public class SmartAgent implements StatusReporter {
         } else if (message instanceof DisassociatedEvent) {
           DisassociatedEvent disassociEvent =
               (DisassociatedEvent) message;
+          // Event for failed master can be repeated published. So ignore it.
+          if (!master.path().address().equals(
+              disassociEvent.remoteAddress())) {
+            return;
+          }
           LOG.warn("Received event: {}, details: {}",
               disassociEvent.eventName(), disassociEvent.toString());
           LOG.warn("Try to register to a new master...");
@@ -402,6 +417,11 @@ public class SmartAgent implements StatusReporter {
         } else if (message instanceof AssociationErrorEvent) {
           AssociationErrorEvent associErrorEvent =
               (AssociationErrorEvent) message;
+          // Event for failed master can be repeated published. So ignore it.
+          if (!master.path().address().equals(
+              associErrorEvent.remoteAddress())) {
+            return;
+          }
           LOG.warn("Received event: {}, details: {}",
               associErrorEvent.eventName(), associErrorEvent.toString());
           LOG.warn("Try to register to a new master...");

--- a/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
+++ b/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
@@ -232,7 +232,8 @@ public class SmartAgent implements StatusReporter {
               .match(ActorInitializationException.class, e -> SupervisorStrategy.stop())
               .match(EndpointAssociationException.class, e -> {
                 getContext().become(new WaitForFindMaster(findMaster()));
-                return SupervisorStrategy.resume();})
+                return SupervisorStrategy.resume();
+              })
               .match(Exception.class, e -> SupervisorStrategy.restart())
               .matchAny(o -> SupervisorStrategy.escalate())
               .build());

--- a/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
+++ b/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
@@ -388,8 +388,8 @@ public class SmartAgent implements StatusReporter {
           Terminated terminated = (Terminated) message;
           if (terminated.getActor().equals(master)) {
             // Go back to WaitForFindMaster context to find new master.
-            LOG.warn("Lost contact with master {}. Try to register to " +
-                "a new master...", getSender());
+            LOG.warn("Lost contact with master {}. Try to register to "
+                + "a new master...", getSender());
             getContext().become(new WaitForFindMaster(findMaster()));
           }
         } else if (message instanceof DisassociatedEvent) {

--- a/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
+++ b/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
@@ -223,18 +223,7 @@ public class SmartAgent implements StatusReporter {
       this.agent = agent;
       this.masters = masters;
       this.conf =  conf;
-
-      this.supervisorStrategy();this.getContext().parent();
-
     }
-
-    private static SupervisorStrategy strategy =
-        new OneForOneStrategy(
-            DeciderBuilder.match(IllegalArgumentException.class, e -> SupervisorStrategy.resume())
-                .match(ActorInitializationException.class, e -> SupervisorStrategy.stop())
-                .match(Exception.class, e -> SupervisorStrategy.restart())
-                .matchAny(o -> SupervisorStrategy.escalate())
-                .build());
 
     @Override
     public SupervisorStrategy supervisorStrategy() {

--- a/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
+++ b/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
@@ -286,7 +286,7 @@ public class SmartAgent implements StatusReporter {
     /**
      * Cache {@code AgentService.Message} or {@code StatusMessage}.
      *
-     * <p> Association related message can be sent repeatedly. We
+     * <p>Association error message can be sent repeatedly. We
      * only need to cache messages related to SSM.
      */
     public void cacheMessage(Object message) {

--- a/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
+++ b/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
@@ -247,9 +247,8 @@ public class SmartAgent implements StatusReporter {
     }
 
     /**
-     * Subscribe two kinds of events: {@code DisassociatedEvent}. It
-     * will be handled by {@link WaitForRegisterAgent#apply method} and
-     * {@link Serve#apply method}.
+     * Subscribe an event: {@code DisassociatedEvent}. It will be handled by
+     * {@link WaitForRegisterAgent#apply method} and {@link Serve#apply method}.
      */
     @Override
     public void preStart() {
@@ -365,9 +364,8 @@ public class SmartAgent implements StatusReporter {
           registerAgent.cancel();
           getContext().watch(master);
           AgentActor.this.id = registered.getAgentId();
-          LOG.info("SmartAgent {} registered to {}",
-              AgentActor.this.id,
-              AgentUtils.getFullPath(getContext().system(), getSelf().path()));
+          LOG.info("SmartAgent {} registered to master: {}",
+              AgentActor.this.id, master.path().address());
           Serve serveContext = new Serve();
           getContext().become(serveContext);
         } else if (message instanceof DisassociatedEvent) {
@@ -438,7 +436,7 @@ public class SmartAgent implements StatusReporter {
           Terminated terminated = (Terminated) message;
           if (terminated.getActor().equals(master)) {
             // Go back to WaitForFindMaster context to find new master.
-            LOG.warn("Lost contact with master {}. Try to register to "
+            LOG.warn("Lost association with master {}. Try to register to "
                 + "a new master...", getSender());
             getContext().become(new WaitForFindMaster(findMaster()));
           }
@@ -486,7 +484,7 @@ public class SmartAgent implements StatusReporter {
       @Override
       public void run() {
         getSelf().tell(PoisonPill.getInstance(), ActorRef.noSender());
-        LOG.info("Failed to find master after {}; Shutting down...", TIMEOUT);
+        LOG.info("Failed to find master after {}, shutting down...", TIMEOUT);
         agent.close();
       }
     }

--- a/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
+++ b/smart-agent/src/main/java/org/smartdata/agent/SmartAgent.java
@@ -408,10 +408,14 @@ public class SmartAgent implements StatusReporter {
       }
 
       private void applyUnhandledMessage() {
+        if (unhandledMessages.isEmpty()) {
+          return;
+        }
+        LOG.info("Applying {} unhandled message(s)...",
+            unhandledMessages.size());
         while (unhandledMessages.size() != 0) {
           Object message = unhandledMessages.pollFirst();
           try {
-            LOG.info("Applying cached message: " + message.toString());
             this.apply(message);
           } catch (Exception e) {
             LOG.warn("Failed to handle message: "

--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentManager.java
@@ -18,6 +18,7 @@
 package org.smartdata.server.engine.cmdlet.agent;
 
 import akka.actor.ActorRef;
+import akka.actor.Address;
 import org.smartdata.server.cluster.NodeInfo;
 import org.smartdata.server.engine.EngineEventBus;
 import org.smartdata.server.engine.cmdlet.agent.messages.MasterToAgent.AgentId;
@@ -78,5 +79,14 @@ public class AgentManager {
 
   AgentId getAgentId(ActorRef agentActorRef) {
     return agents.get(agentActorRef);
+  }
+
+  ActorRef getAgentActorByAddress(Address addr) {
+    for (ActorRef agent : agents.keySet()) {
+      if (agent.path().address().equals(addr)) {
+        return agent;
+      }
+    }
+    return null;
   }
 }

--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentMaster.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentMaster.java
@@ -244,6 +244,7 @@ public class AgentMaster {
       } else if (message instanceof RegisterAgent) {
         RegisterAgent register = (RegisterAgent) message;
         ActorRef agent = getSender();
+        // Watch this agent to listen messages delivered from it.
         getContext().watch(agent);
         AgentId id = register.getId();
         AgentRegistered registered = new AgentRegistered(id);
@@ -289,6 +290,8 @@ public class AgentMaster {
         Terminated terminated = (Terminated) message;
         ActorRef agent = terminated.actor();
         AgentId id = this.agentManager.removeAgent(agent);
+        // Unwatch this agent to avoid trying re-association.
+        this.context().unwatch(agent);
         LOG.warn("SmartAgent ({} {} down", id, agent);
         return true;
       } else {
@@ -303,7 +306,6 @@ public class AgentMaster {
       if (!(message instanceof DisassociatedEvent)) {
         return false;
       }
-
       AssociationEvent associEvent = (AssociationEvent) message;
       ActorRef agent = agentManager.getAgentActorByAddress(
           associEvent.getRemoteAddress());
@@ -316,6 +318,8 @@ public class AgentMaster {
           associEvent.eventName(), associEvent.toString());
       LOG.warn("Removing the disassociated agent: " + agent.path().address());
       agentManager.removeAgent(agent);
+      // Unwatch this agent to avoid trying re-association.
+      this.context().unwatch(agent);
       return true;
     }
   }

--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentMaster.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentMaster.java
@@ -215,8 +215,8 @@ public class AgentMaster {
     }
 
     /**
-     * Subscribe two kinds of events: {@code DisassociatedEvent}.
-     * It will be handled by {@link #handleDisassociatedEvent method}.
+     * Subscribe an event: {@code DisassociatedEvent}. It will be
+     * handled by {@link #handleDisassociatedEvent method}.
      */
     @Override
     public void preStart() {

--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentMaster.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentMaster.java
@@ -215,6 +215,19 @@ public class AgentMaster {
       this.agentManager = agentManager;
     }
 
+    /**
+     * Subscribe two kinds of events: {@code DisassociatedEvent} and
+     * {@code AssociationErrorEvent}. They will be handled by
+     * {@link #handleAssociationEvent method}.
+     */
+    @Override
+    public void preStart() {
+      this.context().system().eventStream().subscribe(
+          self(), DisassociatedEvent.class);
+      this.context().system().eventStream().subscribe(
+          self(), AssociationErrorEvent.class);
+    }
+
     @Override
     public void onReceive(Object message) throws Exception {
       Boolean handled =

--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentMaster.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentMaster.java
@@ -23,7 +23,6 @@ import akka.actor.Props;
 import akka.actor.Terminated;
 import akka.actor.UntypedActor;
 import akka.pattern.Patterns;
-import akka.remote.AssociationErrorEvent;
 import akka.remote.AssociationEvent;
 import akka.remote.DisassociatedEvent;
 import akka.util.Timeout;
@@ -216,16 +215,13 @@ public class AgentMaster {
     }
 
     /**
-     * Subscribe two kinds of events: {@code DisassociatedEvent} and
-     * {@code AssociationErrorEvent}. They will be handled by
-     * {@link #handleAssociationEvent method}.
+     * Subscribe two kinds of events: {@code DisassociatedEvent}.
+     * It will be handled by {@link #handleDisassociatedEvent method}.
      */
     @Override
     public void preStart() {
       this.context().system().eventStream().subscribe(
           self(), DisassociatedEvent.class);
-      this.context().system().eventStream().subscribe(
-          self(), AssociationErrorEvent.class);
     }
 
     @Override
@@ -234,7 +230,7 @@ public class AgentMaster {
           handleAgentMessage(message)
               || handleClientMessage(message)
               || handleTerminatedMessage(message)
-              || handleAssociationEvent(message);
+              || handleDisassociatedEvent(message);
       if (!handled) {
         unhandled(message);
       }
@@ -301,12 +297,10 @@ public class AgentMaster {
     }
 
     /**
-     * Remove agent if {@code DisassociatedEvent} or
-     * {@code AssociationErrorEvent} is received.
+     * Remove agent if {@code DisassociatedEvent} is received.
      */
-    private boolean handleAssociationEvent(Object message) {
-      if (!(message instanceof DisassociatedEvent)
-          && !(message instanceof AssociationErrorEvent)) {
+    private boolean handleDisassociatedEvent(Object message) {
+      if (!(message instanceof DisassociatedEvent)) {
         return false;
       }
 

--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentMaster.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentMaster.java
@@ -292,8 +292,8 @@ public class AgentMaster {
      * {@code AssociationErrorEvent} is received.
      */
     private boolean handleAssociationEvent(Object message) {
-      if (!(message instanceof DisassociatedEvent) &&
-          !(message instanceof AssociationErrorEvent)) {
+      if (!(message instanceof DisassociatedEvent)
+          && !(message instanceof AssociationErrorEvent)) {
         return false;
       }
 

--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentMaster.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/agent/AgentMaster.java
@@ -54,7 +54,8 @@ import scala.concurrent.duration.Duration;
 public class AgentMaster {
 
   private static final Logger LOG = LoggerFactory.getLogger(AgentMaster.class);
-  public static final Timeout TIMEOUT = new Timeout(Duration.create(5, TimeUnit.SECONDS));
+  public static final Timeout TIMEOUT =
+      new Timeout(Duration.create(5, TimeUnit.SECONDS));
 
   private ActorSystem system;
   private ActorRef master;
@@ -83,7 +84,8 @@ public class AgentMaster {
     return getAgentMaster(new SmartConf());
   }
 
-  public static AgentMaster getAgentMaster(SmartConf conf) throws IOException {
+  public static AgentMaster getAgentMaster(SmartConf conf)
+      throws IOException {
     if (agentMaster == null) {
       agentMaster = new AgentMaster(conf);
       return agentMaster;
@@ -105,7 +107,8 @@ public class AgentMaster {
       AgentId agentId = (AgentId) askMaster(launch);
       return agentId.getId();
     } catch (Exception e) {
-      LOG.error("Failed to launch Cmdlet {} due to {}", launch, e.getMessage());
+      LOG.error(
+          "Failed to launch Cmdlet {} due to {}", launch, e.getMessage());
       return null;
     }
   }
@@ -114,27 +117,32 @@ public class AgentMaster {
     try {
       askMaster(new StopCmdlet(cmdletId));
     } catch (Exception e) {
-      LOG.error("Failed to stop Cmdlet {} due to {}", cmdletId, e.getMessage());
+      LOG.error(
+          "Failed to stop Cmdlet {} due to {}", cmdletId, e.getMessage());
     }
   }
 
   public void shutdown() {
     if (system != null && !system.isTerminated()) {
       if (master != null && !master.isTerminated()) {
-        LOG.info("Shutting down master {}...", AgentUtils.getFullPath(system, master.path()));
+        LOG.info("Shutting down master {}...",
+            AgentUtils.getFullPath(system, master.path()));
         system.stop(master);
       }
 
-      LOG.info("Shutting down system {}...", AgentUtils.getSystemAddres(system));
+      LOG.info("Shutting down system {}...",
+          AgentUtils.getSystemAddres(system));
       system.shutdown();
     }
   }
 
   public List<AgentInfo> getAgentInfos() {
     List<AgentInfo> infos = new ArrayList<>();
-    for (Map.Entry<ActorRef, AgentId> entry : agentManager.getAgents().entrySet()) {
+    for (Map.Entry<ActorRef, AgentId> entry :
+        agentManager.getAgents().entrySet()) {
       String location = AgentUtils.getHostPort(entry.getKey());
-      infos.add(new AgentInfo(String.valueOf(entry.getValue().getId()), location));
+      infos.add(new AgentInfo(String.valueOf(
+          entry.getValue().getId()), location));
     }
     return infos;
   }
@@ -165,10 +173,12 @@ public class AgentMaster {
 
     @Override
     public void run() {
-      system = ActorSystem.apply(AgentConstants.MASTER_ACTOR_SYSTEM_NAME, config);
+      system = ActorSystem.apply(
+          AgentConstants.MASTER_ACTOR_SYSTEM_NAME, config);
 
       master = system.actorOf(masterProps, AgentConstants.MASTER_ACTOR_NAME);
-      LOG.info("MasterActor created at {}", AgentUtils.getFullPath(system, master.path()));
+      LOG.info("MasterActor created at {}",
+          AgentUtils.getFullPath(system, master.path()));
       final Thread currentThread = Thread.currentThread();
       Runtime.getRuntime().addShutdownHook(new Thread() {
         @Override
@@ -190,7 +200,8 @@ public class AgentMaster {
     private final Map<Long, ActorRef> dispatches = new HashMap<>();
     private AgentManager agentManager;
 
-    public MasterActor(CmdletManager statusUpdater, AgentManager agentManager) {
+    public MasterActor(CmdletManager statusUpdater,
+        AgentManager agentManager) {
       this(agentManager);
       if (statusUpdater != null) {
         setCmdletManager(statusUpdater);
@@ -214,7 +225,8 @@ public class AgentMaster {
 
     private boolean handleAgentMessage(Object message) {
       if (message instanceof RegisterNewAgent) {
-        getSelf().forward(new RegisterAgent(((RegisterNewAgent) message).getId()), getContext());
+        getSelf().forward(new RegisterAgent(
+            ((RegisterNewAgent) message).getId()), getContext());
         return true;
       } else if (message instanceof RegisterAgent) {
         RegisterAgent register = (RegisterAgent) message;


### PR DESCRIPTION
If master exits gracefully, for example, using 'kill PID' to make master precess exit, `Terminated` message can be received immediately. But a more general scenario is that master node crashes abruptly (mocked by 'kill -9 PID') while agent has dead letters (e.g., cmdlet status report). Under this scenario, agent will spend around 30min to try to associate with master and deliver letters. 

To fix this issue, we enable agent subscribe and listen `DisassociatedEvent`. See AgentActor#preStart in this patch. The so-called context will be shifted to find new master if this event is received.
       