### PR TITLE
Ramdisk action for ec file and delete rules issues

### DIFF
--- a/smart-hadoop-support/smart-hadoop-3.1/src/main/java/org/smartdata/hdfs/CompatibilityHelper31.java
+++ b/smart-hadoop-support/smart-hadoop-3.1/src/main/java/org/smartdata/hdfs/CompatibilityHelper31.java
@@ -266,8 +266,9 @@ public class CompatibilityHelper31 implements CompatibilityHelper {
       // Exclude onessd/onedisk action to be executed on EC block.
       // EC blocks can only be put on a same storage medium.
       if (policyName.equalsIgnoreCase("Warm") |
-          policyName.equalsIgnoreCase("One_SSD")) {
-        throw new IOException("onessd or onedisk is not applicable to EC block!");
+          policyName.equalsIgnoreCase("One_SSD") |
+          policyName.equalsIgnoreCase("Lazy_Persist")) {
+        throw new IOException("onessd/onedisk/ramdisk is not applicable to EC block!");
       }
       if (ErasureCodingPolicyManager
           .checkStoragePolicySuitableForECStripedMode(policyId)) {

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -815,7 +815,9 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
         detailedRuleInfo
           .setBaseProgress(cmdletInfos.size() - currPos);
         detailedRuleInfo.setRunningProgress(countRunning);
-        detailedRuleInfos.add(detailedRuleInfo);
+        if (detailedRuleInfo.getState() != RuleState.DELETED){
+          detailedRuleInfos.add(detailedRuleInfo);
+        }
       }
     }
     return detailedRuleInfos;
@@ -848,7 +850,9 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
             .setBaseProgress(0);
           detailedRuleInfo.setRunningProgress(0);
         }
-        detailedRuleInfos.add(detailedRuleInfo);
+        if (detailedRuleInfo.getState() != RuleState.DELETED){
+          detailedRuleInfos.add(detailedRuleInfo);
+        }
       }
     }
     return detailedRuleInfos;


### PR DESCRIPTION
Hi, I found two issues about SSM UI.
1. As we know, onessd/onedisk/ramdisk is not applicable to EC file. But existing warning exception doesn't include ramdisk action. Then I add "Lazy_Persist" in the exception.
2. The data mover and data sync page both have one problem. When I click the delete button, the rule change state to DELETED. But the rule itself doesn't remove from the list. So I still see the deleted rule in these pages.
Please review. Thanks.