### PR TITLE
Directly use SmartInputStreamFactory to create DFSInputStream

### DIFF
--- a/smart-hadoop-support/smart-hadoop-client-3.1/src/main/java/org/smartdata/hdfs/client/SmartDFSClient.java
+++ b/smart-hadoop-support/smart-hadoop-client-3.1/src/main/java/org/smartdata/hdfs/client/SmartDFSClient.java
@@ -159,26 +159,14 @@ public class SmartDFSClient extends DFSClient {
   @Override
   public DFSInputStream open(String src, int buffersize,
       boolean verifyChecksum) throws IOException {
-    DFSInputStream is = super.open(src, buffersize, verifyChecksum);
-    if (is.getFileLength() == 0) {
-      is.close();
-      FileState fileState = getFileState(src);
-      if (fileState.getFileStage().equals(FileState.FileStage.PROCESSING)) {
-        throw new IOException("Cannot open " + src + " when it is under PROCESSING to "
-            + fileState.getFileType());
-      }
-      is = SmartInputStreamFactory.create(this, src,
-          verifyChecksum, fileState);
-    } else {
-      is.close();
-      FileState fileState = getFileState(src);
-      if (fileState.getFileStage().equals(FileState.FileStage.PROCESSING)) {
-        throw new IOException("Cannot open " + src + " when it is under PROCESSING to "
-            + fileState.getFileType());
-      }
-      is = SmartInputStreamFactory.create(this, src,
-          verifyChecksum, fileState);
+    DFSInputStream is;
+    FileState fileState = getFileState(src);
+    if (fileState.getFileStage().equals(FileState.FileStage.PROCESSING)) {
+      throw new IOException("Cannot open " + src + " when it is under PROCESSING to "
+          + fileState.getFileType());
     }
+    is = SmartInputStreamFactory.create(this, src,
+        verifyChecksum, fileState);
     // Report access event to smart server.
     reportFileAccessEvent(src);
     return is;


### PR DESCRIPTION
Previously without decompression feature, we can firstly use DFS's own api to get inputstream and return it to application if the file length is not zero. And if the file length is zero, we ask SmartInputStreamFactory to create the inputstream. Since we can speculate that the file is compacted by SSM (the original file will be truncated to zero after the compaction). But after SSM compression is introduced, this speculation is useless. Because the compressed file is not zero at all.