### PR TITLE
Fix compression owner and ec filelock issues.

### DIFF
--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CompressionAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CompressionAction.java
@@ -175,6 +175,8 @@ public class CompressionAction extends HdfsAction {
 
         compress(in, out);
         HdfsFileStatus destFile = dfsClient.getFileInfo(compressTmpPath);
+        dfsClient.setOwner(compressTmpPath, srcFile.getOwner(), srcFile.getGroup());
+        dfsClient.setPermission(compressTmpPath, srcFile.getPermission());
         compressionFileState.setCompressedLength(destFile.getLen());
         appendLog("Compressed file length: " + destFile.getLen());
         compressionFileInfo =

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/DecompressionAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/DecompressionAction.java
@@ -109,6 +109,8 @@ public class DecompressionAction extends HdfsAction {
       long length = dfsClient.getFileInfo(filePath).getLen();
       outputDecompressedData(in, out, (int) length);
       // Overwrite the original file with decompressed data
+      dfsClient.setOwner(compressTmpPath, dfsClient.getFileInfo(filePath).getOwner(), dfsClient.getFileInfo(filePath).getGroup());
+      dfsClient.setPermission(compressTmpPath, dfsClient.getFileInfo(filePath).getPermission());
       dfsClient.rename(compressTmpPath, filePath, Options.Rename.OVERWRITE);
       appendLog("The given file is successfully decompressed by codec: " +
           ((CompressionFileState) fileState).getCompressionImpl());

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/ErasureCodingScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/ErasureCodingScheduler.java
@@ -244,10 +244,10 @@ public class ErasureCodingScheduler extends ActionSchedulerService {
         actionInfo.getActionName().equals(UNEC_ACTION_ID)) {
       String filePath = null;
       try {
+        filePath = actionInfo.getArgs().get(HdfsAction.FILE_PATH);
         if (!actionInfo.isSuccessful()) {
           return;
         }
-        filePath = actionInfo.getArgs().get(HdfsAction.FILE_PATH);
         // Task over access count after successful execution.
         takeOverAccessCount(filePath);
       } finally {


### PR DESCRIPTION
There are two problems in compression and ec process.
1. The files owner is changed after compress/decompress action.
2. If the ec action failed, the filelock can't be removed. It causes other ec actions rejected by scheduler.