### PR TITLE
Add empty action check and fix rule start time issue.

### DIFF
--- a/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smartdata.AbstractService;
@@ -360,6 +361,9 @@ public class CmdletManager extends AbstractService {
   public long submitCmdlet(String cmdlet) throws IOException {
     LOG.debug(String.format("Received Cmdlet -> [ %s ]", cmdlet));
     try {
+      if (StringUtils.isBlank(cmdlet)) {
+        throw new IOException("Cannot submit an empty action!");
+      }
       CmdletDescriptor cmdletDescriptor = CmdletDescriptor.fromCmdletString(cmdlet);
       return submitCmdlet(cmdletDescriptor);
     } catch (ParseException e) {

--- a/smart-engine/src/main/java/org/smartdata/server/engine/RuleManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/RuleManager.java
@@ -312,12 +312,6 @@ public class RuleManager extends AbstractService {
         RuleExecutor ruleExecutor = infoRepo.launchExecutor(this);
         TranslateResult tr = ruleExecutor.getTranslateResult();
         TimeBasedScheduleInfo si = tr.getTbScheduleInfo();
-        long lastCheckTime = rule.getLastCheckTime();
-        long every = si.getBaseEvery();
-        every = every == 0 ? 5000 : every;
-        long now = System.currentTimeMillis();
-        long delay = every - ((now - lastCheckTime) % every);
-        si.setStartTime(now + delay);
         if (rule.getLastCheckTime() != 0) {
           si.setFirstCheckTime(rule.getLastCheckTime());
         }


### PR DESCRIPTION
There is a problem for resetting start time of rule in SSM server starting process. When I submitted a rule like "from 2020-10-08 22:00:00 to 2020-10-08 23:00:00" to start rule at the fixed time, the start time of this rule will be reset if server restart or HA happens. It leads to the rule triggered ahead of fixed time. I'm not sure about the purpose of resetting the start time when server started.