### PR TITLE
Fix JAVA_OPTS typos in common.sh

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -288,7 +288,7 @@ function init_command() {
       ALLOW_DAEMON_OPT=true
       SMART_VARGS+=" -format"
       JAVA_OPTS+=" -Dsmart.log.file="${SMART_LOG_FILE_NAME}
-      JAVA_OPST+=" ${SSM_JAVA_OPT} ${SSM_SERVER_JAVA_OPT}"
+      JAVA_OPTS+=" ${SSM_JAVA_OPT} ${SSM_SERVER_JAVA_OPT}"
     ;;
     smartserver)
       SMART_CLASSNAME=org.smartdata.server.SmartDaemon
@@ -298,7 +298,7 @@ function init_command() {
         JAVA_OPTS+=" -Xdebug -Xrunjdwp:transport=dt_socket,address=8008,server=y,suspend=y"
       fi
       JAVA_OPTS+=" -Dsmart.log.file="${SMART_LOG_FILE_NAME}
-      JAVA_OPST+=" ${SSM_JAVA_OPT} ${SSM_SERVER_JAVA_OPT}"
+      JAVA_OPTS+=" ${SSM_JAVA_OPT} ${SSM_SERVER_JAVA_OPT}"
       SMART_VARGS+=" -D smart.agent.master.address="${SSM_EXEC_HOST}
       reorder_lib
     ;;
@@ -312,7 +312,7 @@ function init_command() {
        JAVA_OPTS+=" -Xdebug -Xrunjdwp:transport=dt_socket,address=8008,server=y,suspend=y"
       fi
       JAVA_OPTS+=" -Dsmart.log.file="${SMART_LOG_FILE_NAME}
-      JAVA_OPST+=" ${SSM_JAVA_OPT} ${SSM_AGENT_JAVA_OPT}"
+      JAVA_OPTS+=" ${SSM_JAVA_OPT} ${SSM_AGENT_JAVA_OPT}"
       SMART_VARGS+=" -D smart.agent.address="${SSM_EXEC_HOST}
     ;;
     standby)
@@ -325,7 +325,7 @@ function init_command() {
         JAVA_OPTS+=" -Xdebug -Xrunjdwp:transport=dt_socket,address=8008,server=y,suspend=y"
       fi
       JAVA_OPTS+=" -Dsmart.log.file="${SMART_LOG_FILE_NAME}
-      JAVA_OPST+=" ${SSM_JAVA_OPT} ${SSM_SERVER_JAVA_OPT}"
+      JAVA_OPTS+=" ${SSM_JAVA_OPT} ${SSM_SERVER_JAVA_OPT}"
       SMART_VARGS+=" -D smart.agent.master.address="${SSM_EXEC_HOST}
       reorder_lib
     ;;


### PR DESCRIPTION
There are JAVA_OPTS typos in 'common.sh'. This results in invalid settings for service max java heap size.
![image](https://user-images.githubusercontent.com/32612402/100840364-bb86e380-34b0-11eb-9224-e6c36ef4f0ae.png)
![image](https://user-images.githubusercontent.com/32612402/100840368-bcb81080-34b0-11eb-8efd-d8e88b2969c4.png)
