### PR TITLE
Fix int overflow issue in decompression process

### DIFF
--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/DecompressionAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/DecompressionAction.java
@@ -107,7 +107,7 @@ public class DecompressionAction extends HdfsAction {
 
       in = dfsClient.open(filePath);
       long length = dfsClient.getFileInfo(filePath).getLen();
-      outputDecompressedData(in, out, (int) length);
+      outputDecompressedData(in, out, length);
       // Overwrite the original file with decompressed data
       dfsClient.setOwner(compressTmpPath, dfsClient.getFileInfo(filePath).getOwner(), dfsClient.getFileInfo(filePath).getGroup());
       dfsClient.setPermission(compressTmpPath, dfsClient.getFileInfo(filePath).getPermission());
@@ -128,12 +128,12 @@ public class DecompressionAction extends HdfsAction {
   }
 
   private void outputDecompressedData(InputStream in,
-      OutputStream out, int length)
+      OutputStream out, long length)
       throws IOException {
     byte[] buff = new byte[buffSize];
-    int remainSize = length;
+    long  remainSize = length;
     while (remainSize != 0) {
-      int copySize = remainSize < buffSize ? remainSize : buffSize;
+      int copySize = remainSize < buffSize ? (int) remainSize : buffSize;
       int readSize = in.read(buff, 0, copySize);
       if (readSize == -1) {
         break;


### PR DESCRIPTION
When the compressed file length is large, casting long type to int type leads to overflow.
![image](https://user-images.githubusercontent.com/32612402/102453435-2b7f9700-4077-11eb-9a70-fc11aa6c2ca4.png)
![image](https://user-images.githubusercontent.com/32612402/102453448-30dce180-4077-11eb-966f-f4339c021040.png)
![image](https://user-images.githubusercontent.com/32612402/102453458-333f3b80-4077-11eb-9290-baa350b2b016.png)
