### PR TITLE
Modify the calculation method of compression buffersize

### DIFF
--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CompressionAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CompressionAction.java
@@ -232,7 +232,7 @@ public class CompressionAction extends HdfsAction {
   private int getActualBuffSize(long fileSize) {
     // The capacity of originalPos and compressedPos is maxSplit (1000, by default) in database
     // Calculated by max number of splits.
-    int calculatedBufferSize = (int) (fileSize / maxSplit);
+    int calculatedBufferSize = ((int) (fileSize / (bufferSize * maxSplit)) + 1) * bufferSize;
     LOG.debug("Calculated buffer size: " + calculatedBufferSize);
     LOG.debug("MaxSplit: " + maxSplit);
     // Determine the actual buffer size


### PR DESCRIPTION
When the calculated buffer size is an integral multiple of the buffer size, decompressing the file does not increase the size of the file. At the same time, it can also ensure that xattr will not be too large.