### PR TITLE
Make the same dfsclient in recheck process of move action.

### DIFF
--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletFactory.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletFactory.java
@@ -29,7 +29,6 @@ import org.smartdata.action.SmartAction;
 import org.smartdata.conf.SmartConfKeys;
 import org.smartdata.hdfs.HadoopUtil;
 import org.smartdata.hdfs.action.HdfsAction;
-import org.smartdata.hdfs.action.MoveFileAction;
 import org.smartdata.hdfs.client.SmartDFSClient;
 import org.smartdata.model.LaunchAction;
 import org.smartdata.protocol.message.LaunchCmdlet;
@@ -75,18 +74,7 @@ public class CmdletFactory {
     smartAction.setLastAction(isLastAction);
     smartAction.init(launchAction.getArgs());
     smartAction.setActionId(launchAction.getActionId());
-    if (smartAction instanceof MoveFileAction) {
-      try {
-        ((HdfsAction) smartAction)
-                .setDfsClient(
-                        HadoopUtil.getDFSClient(
-                                HadoopUtil.getNameNodeUri(smartContext.getConf()),
-                                smartContext.getConf()));
-      } catch (IOException e) {
-        LOG.error("smartAction aid={} setDfsClient error", launchAction.getActionId(), e);
-        throw new ActionException(e);
-      }
-    } else if (smartAction instanceof HdfsAction) {
+    if (smartAction instanceof HdfsAction) {
       try {
         ((HdfsAction) smartAction)
             .setDfsClient(

--- a/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletFactory.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/cmdlet/CmdletFactory.java
@@ -29,6 +29,7 @@ import org.smartdata.action.SmartAction;
 import org.smartdata.conf.SmartConfKeys;
 import org.smartdata.hdfs.HadoopUtil;
 import org.smartdata.hdfs.action.HdfsAction;
+import org.smartdata.hdfs.action.MoveFileAction;
 import org.smartdata.hdfs.client.SmartDFSClient;
 import org.smartdata.model.LaunchAction;
 import org.smartdata.protocol.message.LaunchCmdlet;
@@ -74,7 +75,18 @@ public class CmdletFactory {
     smartAction.setLastAction(isLastAction);
     smartAction.init(launchAction.getArgs());
     smartAction.setActionId(launchAction.getActionId());
-    if (smartAction instanceof HdfsAction) {
+    if (smartAction instanceof MoveFileAction) {
+      try {
+        ((HdfsAction) smartAction)
+                .setDfsClient(
+                        HadoopUtil.getDFSClient(
+                                HadoopUtil.getNameNodeUri(smartContext.getConf()),
+                                smartContext.getConf()));
+      } catch (IOException e) {
+        LOG.error("smartAction aid={} setDfsClient error", launchAction.getActionId(), e);
+        throw new ActionException(e);
+      }
+    } else if (smartAction instanceof HdfsAction) {
       try {
         ((HdfsAction) smartAction)
             .setDfsClient(

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/MoveFileAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/MoveFileAction.java
@@ -23,6 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smartdata.action.ActionType;
 import org.smartdata.action.Utils;
+import org.smartdata.conf.SmartConf;
+import org.smartdata.hdfs.HadoopUtil;
 import org.smartdata.hdfs.action.move.AbstractMoveFileAction;
 import org.smartdata.hdfs.action.move.MoverExecutor;
 import org.smartdata.hdfs.action.move.MoverStatus;
@@ -40,6 +42,7 @@ public class MoveFileAction extends AbstractMoveFileAction {
   private String storagePolicy;
   private String fileName;
   private FileMovePlan movePlan;
+  private SmartConf conf;
 
   public MoveFileAction() {
     super();
@@ -55,6 +58,7 @@ public class MoveFileAction extends AbstractMoveFileAction {
   public void init(Map<String, String> args) {
     super.init(args);
     this.fileName = args.get(FILE_PATH);
+    this.conf = getContext().getConf();
     this.storagePolicy = getStoragePolicy() != null ?
         getStoragePolicy() : args.get(STORAGE_POLICY);
     if (args.containsKey(MOVE_PLAN)) {
@@ -69,6 +73,8 @@ public class MoveFileAction extends AbstractMoveFileAction {
 
   @Override
   protected void execute() throws Exception {
+    this.setDfsClient(HadoopUtil.getDFSClient(
+            HadoopUtil.getNameNodeUri(conf), conf));
     if (fileName == null) {
       throw new IllegalArgumentException("File parameter is missing!");
     }


### PR DESCRIPTION
Move action will recheck file length in execute process. If the file is compressed, it will compare the original length with compressed length because of two different dfsclients. As a result, moving compressed file cannot update sid. So, I replace smartDFSClient with DFSClient for MoveFileAction.