### PR TITLE
Fix whitelist check and fetch list issue.

### DIFF
--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventFetcher.java
@@ -315,7 +315,7 @@ public class InotifyEventFetcher {
     }
 
     public List<String> getFetchDirFromConfig() {
-      this.conf.getCoverDir();
+      fetchList = conf.getCoverDir();
       return fetchList;
     }
 

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventFetcher.java
@@ -233,6 +233,9 @@ public class InotifyEventFetcher {
    */
   public static boolean isWhitelistChanged(SmartConf conf, MetaStore metaStore) {
     List<String> currentList = conf.getCoverDir();
+    if (currentList.isEmpty()) {
+      currentList.add("/");
+    }
     try {
       oldList = metaStore.getLastFetchedDirs();
     } catch (MetaStoreException e) {

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventFetcher.java
@@ -310,13 +310,11 @@ public class InotifyEventFetcher {
     }
 
     public List<String> getIgnoreDirFromConfig() {
-      ignoreList = conf.getIgnoreDir();
-      return ignoreList;
+      return conf.getIgnoreDir();
     }
 
     public List<String> getFetchDirFromConfig() {
-      fetchList = conf.getCoverDir();
-      return fetchList;
+      return conf.getCoverDir();
     }
 
     public boolean shouldIgnore(String path) {

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CompressionScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CompressionScheduler.java
@@ -163,7 +163,7 @@ public class CompressionScheduler extends ActionSchedulerService {
     if (fileState instanceof CompressionFileState) {
       return true;
     }
-    LOG.warn("A compressed file path should be given!");
+    LOG.debug("A compressed file path should be given!");
     return false;
   }
 


### PR DESCRIPTION
The old whitelist is set to "/" in database when the whilelist is not configured. While the current whilelist is null, it will judge these to be different in whilelist check. So, I set current whilelist to "/" when it's empty.
In addition, there are two minor problems in fetch list and decompression. I make a simple modification.