### PR TITLE
Fix whitelist and uncompact actions lock issues.

### DIFF
--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventFetcher.java
@@ -121,9 +121,6 @@ public class InotifyEventFetcher {
       //Update old whitelist
       try {
         String currentList = StringUtil.join(",", conf.getCoverDir());
-        if (currentList.isEmpty()){
-          currentList = "/";
-        }
         metaStore.updateWhitelistTable(currentList);
       } catch (MetaStoreException e) {
         LOG.warn("Failed to update whitelist.", e);
@@ -233,9 +230,6 @@ public class InotifyEventFetcher {
    */
   public static boolean isWhitelistChanged(SmartConf conf, MetaStore metaStore) {
     List<String> currentList = conf.getCoverDir();
-    if (currentList.isEmpty()) {
-      currentList.add("/");
-    }
     try {
       oldList = metaStore.getLastFetchedDirs();
     } catch (MetaStoreException e) {

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/SmallFileScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/SmallFileScheduler.java
@@ -144,7 +144,9 @@ public class SmallFileScheduler extends ActionSchedulerService {
         !actionInfo.getActionName().equals(UNCOMPACT_ACTION_NAME)) {
       return;
     }
-    compactSmallFileLock.addAll(getSmallFileList(actionInfo));
+    if (actionInfo.getActionName().equals(COMPACT_ACTION_NAME)) {
+      compactSmallFileLock.addAll(getSmallFileList(actionInfo));
+    }
     containerFileLock.add(getContainerFile(actionInfo));
   }
 

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -85,6 +85,7 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2483,10 +2484,11 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
    */
   public List<String> getLastFetchedDirs() throws MetaStoreException {
     try {
-      String[] oldList = whitelistDao.getLastFetchedDirs().split(",");
       List<String> lastFetchedDirs = new ArrayList<>();
-      for (String s : oldList) {
-        lastFetchedDirs.add(s + (s.endsWith("/") ? "" : "/"));
+      String fetchedList = whitelistDao.getLastFetchedDirs();
+      if (!fetchedList.isEmpty()) {
+        String[] oldList = fetchedList.split(",");
+        lastFetchedDirs.addAll(Arrays.asList(oldList));
       }
       LOG.info("Last fetch dirs are " + lastFetchedDirs.toString());
       return lastFetchedDirs;


### PR DESCRIPTION
Hi, there are two issues about whitelist and uncompact actions.
1. When user didn't set whitelist, adding "/" to currentList will influence coverList in SmartConf and leads to other problems. So I changed related process.
2. Recover method will add lock to smallfileList in uncompact actions when HA happened. But when uncompact actions finished, the lock won't be removed. I think it is not necessary to add samllfileList lock for uncompact actions.
This patch will solve these problems, please review.